### PR TITLE
Sync history conversation of the Chat

### DIFF
--- a/example.js
+++ b/example.js
@@ -450,7 +450,7 @@ client.on('message', async msg => {
          */
         const result = await msg.pin(60); // Will pin a message for 1 minute
         console.log(result); // True if the operation completed successfully, false otherwise
-    }else if (msg.body === '!howManyConnections'){
+    } else if (msg.body === '!howManyConnections') {
         /**
          * Get user device count by ID
          * Each WaWeb Connection counts as one device, and the phone (if exists) counts as one
@@ -458,6 +458,13 @@ client.on('message', async msg => {
          */
         let deviceCount = await client.getContactDeviceCount(msg.from);
         await msg.reply(`You have *${deviceCount}* devices connected`);
+    } else if (msg.body === '!syncHistory') {
+        const isSynced = await client.syncHistory(msg.from);
+        if (isSynced) {
+            msg.reply('Historical chat is syncing..');
+        } else {
+            msg.reply('There is no historical chat to sync.');
+        }
     }
 });
 

--- a/example.js
+++ b/example.js
@@ -460,11 +460,11 @@ client.on('message', async msg => {
         await msg.reply(`You have *${deviceCount}* devices connected`);
     } else if (msg.body === '!syncHistory') {
         const isSynced = await client.syncHistory(msg.from);
-        if (isSynced) {
-            msg.reply('Historical chat is syncing..');
-        } else {
-            msg.reply('There is no historical chat to sync.');
-        }
+        // Or through the Chat object:
+        // const chat = await client.getChatById(msg.from);
+        // const isSynced = await chat.syncHistory();
+        
+        await msg.reply(isSynced ? 'Historical chat is syncing..' : 'There is no historical chat to sync.');
     }
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1443,6 +1443,8 @@ declare namespace WAWebJS {
         getLabels: () => Promise<Label[]>,
         /** Add or remove labels to this Chat */
         changeLabels: (labelIds: Array<string | number>) => Promise<void>
+        /** Sync history conversation of the Chat */
+        syncHistory: () => Promise<boolean>
     }
 
     export interface MessageSearchOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -183,7 +183,10 @@ declare namespace WAWebJS {
          * So for a non-enterprise user with one WaWeb connection it should return "2"
          * @param {string} contactId
          */
-        getContactDeviceCount(contactId: string): Promise<Number>          
+        getContactDeviceCount(contactId: string): Promise<Number>
+        
+        /** Sync history conversation of the Chat */
+        syncHistory(chatId: string): Promise<boolean>
         
         /** Changes and returns the archive state of the Chat */
         unarchiveChat(chatId: string): Promise<boolean>

--- a/src/Client.js
+++ b/src/Client.js
@@ -1739,6 +1739,24 @@ class Client extends EventEmitter {
         }
         return 0;
     }
+
+    /**
+     * Sync history conversation
+     * @param {string} chatId
+     * @return {boolean} true/false
+     */
+    async syncHistory(chatId) {
+        return await this.pupPage.evaluate(async (chatId) => {
+            const chat = await window.WWebJS.getChat(chatId);
+            if (chat.endOfHistoryTransferType == window.Store.HistoryStates.COMPLETE_BUT_MORE_MESSAGES_REMAIN_ON_PRIMARY) {
+                window.Store.HistorySync.sendPeerDataOperationRequest(window.require("WAWebProtobufsE2E.pb").Message$PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND, {
+                    chatId: chat.id
+                });
+                return true;
+            }
+            return false;
+        }, chatId);
+    }
 }
 
 module.exports = Client;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1741,9 +1741,9 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Sync history conversation
+     * Sync chat history conversation
      * @param {string} chatId
-     * @return {boolean} true/false
+     * @return {Promise<boolean>} True if operation completed successfully, false otherwise.
      */
     async syncHistory(chatId) {
         return this.pupPage.evaluate(async (chatId) => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -1749,7 +1749,7 @@ class Client extends EventEmitter {
         return this.pupPage.evaluate(async (chatId) => {
             const chat = await window.WWebJS.getChat(chatId);
             if (chat.endOfHistoryTransferType === 0) {
-                window.Store.HistorySync.sendPeerDataOperationRequest(3, {
+                await window.Store.HistorySync.sendPeerDataOperationRequest(3, {
                     chatId: chat.id
                 });
                 return true;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1746,10 +1746,10 @@ class Client extends EventEmitter {
      * @return {boolean} true/false
      */
     async syncHistory(chatId) {
-        return await this.pupPage.evaluate(async (chatId) => {
+        return this.pupPage.evaluate(async (chatId) => {
             const chat = await window.WWebJS.getChat(chatId);
-            if (chat.endOfHistoryTransferType == window.Store.HistoryStates.COMPLETE_BUT_MORE_MESSAGES_REMAIN_ON_PRIMARY) {
-                window.Store.HistorySync.sendPeerDataOperationRequest(window.require("WAWebProtobufsE2E.pb").Message$PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND, {
+            if (chat.endOfHistoryTransferType === 0) {
+                window.Store.HistorySync.sendPeerDataOperationRequest(3, {
                     chatId: chat.id
                 });
                 return true;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1746,7 +1746,7 @@ class Client extends EventEmitter {
      * @return {Promise<boolean>} True if operation completed successfully, false otherwise.
      */
     async syncHistory(chatId) {
-        return this.pupPage.evaluate(async (chatId) => {
+        return await this.pupPage.evaluate(async (chatId) => {
             const chat = await window.WWebJS.getChat(chatId);
             if (chat.endOfHistoryTransferType === 0) {
                 await window.Store.HistorySync.sendPeerDataOperationRequest(3, {

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -270,6 +270,14 @@ class Chat extends Base {
     async changeLabels(labelIds) {
         return this.client.addOrRemoveLabels(labelIds, [this.id._serialized]);
     }
+
+    /**
+     * Sync chat history conversation
+     * @return {Promise<boolean>} True if operation completed successfully, false otherwise.
+     */
+    async syncHistory() {
+        return this.client.syncHistory(this.id._serialized);
+    }
 }
 
 module.exports = Chat;

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -98,6 +98,8 @@ exports.ExposeStore = () => {
     window.Store.BotSecret = window.require('WAWebBotMessageSecret');
     window.Store.BotProfiles = window.require('WAWebBotProfileCollection');
     window.Store.DeviceList = window.require('WAWebApiDeviceList');
+    window.Store.HistoryStates = window.require("WAWebChatConstants").ConversationEndOfHistoryTransferModelPropType;
+    window.Store.HistorySync = window.require('WAWebSendNonMessageDataRequest');
     if (window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.1014111620')) 
         window.Store.AddonReactionTable = window.require('WAWebAddonReactionTableMode').reactionTableMode;
     

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -98,7 +98,6 @@ exports.ExposeStore = () => {
     window.Store.BotSecret = window.require('WAWebBotMessageSecret');
     window.Store.BotProfiles = window.require('WAWebBotProfileCollection');
     window.Store.DeviceList = window.require('WAWebApiDeviceList');
-    window.Store.HistoryStates = window.require("WAWebChatConstants").ConversationEndOfHistoryTransferModelPropType;
     window.Store.HistorySync = window.require('WAWebSendNonMessageDataRequest');
     if (window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.1014111620')) 
         window.Store.AddonReactionTable = window.require('WAWebAddonReactionTableMode').reactionTableMode;


### PR DESCRIPTION
# PR Details

Sync history conversation of the Chat

## Description

Able to sync historical message of the Chat

## Related Issue

closes #2937

## Motivation and Context

After historical messages are synced, you can fetch older messages content, images, attachment and audio.

## How Has This Been Tested

User can type !syncHistory to sync the historical message, alternatively, can change the chatId in await client.syncHistory(chatId); to test out

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).



