### PR TITLE
fix: restore customer notes support on recent WhatsApp Web versions

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -3326,29 +3326,27 @@ class Client extends EventEmitter {
     /**
      * Add or edit a customer note
      * @see https://faq.whatsapp.com/1433099287594476
-     * @param {string} userId The ID of a customer to add a note to
-     * @param {string} note The note to add
+     * @param {string} userId The customer chat ID
+     * @param {string} note The note content
      * @returns {Promise<void>}
      */
     async addOrEditCustomerNote(userId, note) {
-        return await this.pupPage.evaluate(
+        await this.pupPage.evaluate(
             async (userId, note) => {
-                if (!window.require('WAWebBizGatingUtils').smbNotesV1Enabled())
-                    return;
+                const BizNotesGatingUtils = window.require(
+                    'WAWebBizNotesGatingUtils',
+                );
 
-                return window
-                    .require('WAWebNoteAction')
-                    .noteAddAction(
-                        'unstructured',
-                        window
-                            .require('WAWebWidToJid')
-                            .widToUserJid(
-                                window
-                                    .require('WAWebWidFactory')
-                                    .createWid(userId),
-                            ),
-                        note,
-                    );
+                if (!BizNotesGatingUtils?.smbNotesV1Enabled?.()) return;
+
+                const NoteAction = window.require('WAWebNoteAction');
+                const WidFactory = window.require('WAWebWidFactory');
+                const WidToJid = window.require('WAWebWidToJid');
+
+                const chatWid = WidFactory.createWid(userId);
+                const chatJid = WidToJid.widToUserJid(chatWid);
+
+                await NoteAction.noteAddAction('unstructured', chatJid, note);
             },
             userId,
             note,
@@ -3358,41 +3356,47 @@ class Client extends EventEmitter {
     /**
      * Get a customer note
      * @see https://faq.whatsapp.com/1433099287594476
-     * @param {string} userId The ID of a customer to get a note from
+     * @param {string} userId The customer chat ID
      * @returns {Promise<{
+     *    id: string,
      *    chatId: string,
+     *    type: string
      *    content: string,
      *    createdAt: number,
-     *    id: string,
-     *    modifiedAt: number,
-     *    type: string
-     * }>}
+     *    modifiedAt: number
+     * } | null>}
      */
     async getCustomerNote(userId) {
         return await this.pupPage.evaluate(async (userId) => {
-            if (!window.require('WAWebBizGatingUtils').smbNotesV1Enabled())
-                return null;
+            const BizNotesGatingUtils = window.require(
+                'WAWebBizNotesGatingUtils',
+            );
 
-            const note = await window
-                .require('WAWebNoteAction')
-                .retrieveOnlyNoteForChatJid(
-                    window
-                        .require('WAWebWidToJid')
-                        .widToUserJid(
-                            window.require('WAWebWidFactory').createWid(userId),
-                        ),
-                );
+            if (!BizNotesGatingUtils?.smbNotesV1Enabled?.()) return null;
 
-            let serialized = note?.serialize();
+            const NoteAction = window.require('WAWebNoteAction');
+            const WidFactory = window.require('WAWebWidFactory');
+            const WidToJid = window.require('WAWebWidToJid');
+            const JidToWid = window.require('WAWebJidToWid');
+
+            const chatWid = WidFactory.createWid(userId);
+            const chatJid = WidToJid.widToUserJid(chatWid);
+
+            const note = await NoteAction.retrieveOnlyNoteForChatJid(chatJid);
+
+            const serialized = note?.serialize();
 
             if (!serialized) return null;
 
-            serialized.chatId = window
-                .require('WAWebJidToWid')
-                .userJidToUserWid(serialized.chatJid)._serialized;
-            delete serialized.chatJid;
-
-            return serialized;
+            return {
+                id: serialized.id,
+                chatId: JidToWid.userJidToUserWid(serialized.chatJid)
+                    ._serialized,
+                type: serialized.type,
+                content: serialized.content,
+                createdAt: serialized.createdAt,
+                modifiedAt: serialized.modifiedAt,
+            };
         }, userId);
     }
 


### PR DESCRIPTION
## Description

This pull request restores customer notes support on recent WhatsApp Web versions.

`WAWebBizGatingUtils.smbNotesV1Enabled` is no longer available in newer WhatsApp Web builds. This PR updates the implementation to use `WAWebBizNotesGatingUtils.smbNotesV1Enabled`, which is currently used internally by WhatsApp Web.

## Testing Summary

Tested customer note creation, editing, retrieval, and synchronization across devices.

### Test Details

```js
client.on("ready", async () => {
	const phoneNumber = "XXXXXXXXXXXX";
	const chat = await client.getChatById(`${phoneNumber}@c.us`);

	// Adding or Editing Customer Note
	await chat.addOrEditCustomerNote("Testing Customer Note Text");

	// Retrieving Customer Note
	const customerNote = await chat.getCustomerNote();
	console.log(customerNote);
});
```

Output:

```txt
{
  id: 'zTytocKP8+2aRzmeHo67SERxirBnVgMYuoG2EJHn8cQ=',
  chatId: 'XXXXXXXXXXXXXXXX@lid',
  type: 'unstructured',
  content: 'Testing Customer Note Text',
  createdAt: 1779910224,
  modifiedAt: 1779910224
}
```

### Environment

- Machine OS: Debian 13
- Phone OS: Android 15
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1040229458
- Browser Type and Version: Google Chrome
- Node Version: v24.12.0

## Type of Change

<!-- Select all that apply: -->

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

<!-- Please confirm that all relevant items below have been completed. -->

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
