### PR TITLE
feat: add native sticker pack send support

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,12 @@
-const { Client, Location, Poll, List, Buttons, LocalAuth } = require('./index');
+const {
+    Client,
+    Location,
+    Poll,
+    List,
+    Buttons,
+    LocalAuth,
+    MessageMedia,
+} = require('./index');
 
 const client = new Client({
     authStrategy: new LocalAuth(),
@@ -265,6 +273,26 @@ client.on('message', async (msg) => {
                 sendAudioAsVoice: true,
             });
         }
+    } else if (msg.body === '!pack') {
+        // Send an array of MessageMedia as a native sticker pack.
+        const urls = [1, 2, 3, 4].map(
+            (n) =>
+                `https://api.dicebear.com/9.x/shapes/png?seed=wwebjs-${n}&size=512`,
+        );
+        const stickers = await Promise.all(
+            urls.map((url) => MessageMedia.fromUrl(url, { unsafeMime: true })),
+        );
+
+        await client.sendMessage(msg.from, stickers, {
+            sendMediaAsStickerPack: true,
+            stickerPackName: 'WWebJS Pack',
+            stickerPackPublisher: 'whatsapp-web.js',
+            // Optional custom tray icon; defaults to the first sticker:
+            // stickerPackTrayIcon: await MessageMedia.fromUrl(
+            //     'https://wwebjs.dev/images/logo.png',
+            //     { unsafeMime: true },
+            // ),
+        });
     } else if (msg.body === '!isviewonce' && msg.hasQuotedMsg) {
         const quotedMsg = await msg.getQuotedMessage();
         if (quotedMsg.hasMedia) {

--- a/example.js
+++ b/example.js
@@ -274,11 +274,17 @@ client.on('message', async (msg) => {
             });
         }
     } else if (msg.body === '!pack') {
-        // Send an array of MessageMedia as a native sticker pack.
-        const urls = [1, 2, 3, 4].map(
-            (n) =>
-                `https://api.dicebear.com/9.x/shapes/png?seed=wwebjs-${n}&size=512`,
-        );
+        const urls = [
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-588087217.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-318328813.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-1069240662.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-1062658684.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-324740484.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-294350008.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-261131050.png',
+            'https://sticker-ly-api.sergiooak.com.br/file/sticker_pack/MGU8sA927ahRF7KMT9dluA/PTHH2U/42/-232537276.png',
+        ];
+
         const stickers = await Promise.all(
             urls.map((url) => MessageMedia.fromUrl(url, { unsafeMime: true })),
         );
@@ -288,10 +294,7 @@ client.on('message', async (msg) => {
             stickerPackName: 'WWebJS Pack',
             stickerPackPublisher: 'whatsapp-web.js',
             // Optional custom tray icon; defaults to the first sticker:
-            // stickerPackTrayIcon: await MessageMedia.fromUrl(
-            //     'https://wwebjs.dev/images/logo.png',
-            //     { unsafeMime: true },
-            // ),
+            // stickerPackTrayIcon: await MessageMedia.fromUrl('https://wwebjs.dev/images/logo.png', {unsafeMime: true},),
         });
     } else if (msg.body === '!isviewonce' && msg.hasQuotedMsg) {
         const quotedMsg = await msg.getQuotedMessage();

--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ declare namespace WAWebJS {
         ): Promise<string>;
 
         /** Cancels an active pairing code session and returns to QR code mode */
-        cancelPairingCode(): Promise<void>
+        cancelPairingCode(): Promise<void>;
 
         /** Force reset of connection state for the client */
         resetState(): Promise<void>;
@@ -211,10 +211,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
@@ -1076,6 +1073,7 @@ declare namespace WAWebJS {
         VIDEO = 'video',
         DOCUMENT = 'document',
         STICKER = 'sticker',
+        STICKER_PACK = 'sticker-pack',
         LOCATION = 'location',
         CONTACT_CARD = 'vcard',
         CONTACT_CARD_MULTI = 'multi_vcard',
@@ -1554,6 +1552,8 @@ declare namespace WAWebJS {
         sendVideoAsGif?: boolean;
         /** Send media as sticker */
         sendMediaAsSticker?: boolean;
+        /** Send a MessageMedia array as a sticker pack */
+        sendMediaAsStickerPack?: boolean;
         /** Send media as document */
         sendMediaAsDocument?: boolean;
         /** Send media as quality HD */
@@ -1589,6 +1589,14 @@ declare namespace WAWebJS {
         stickerAuthor?: string;
         /** Sticker categories, if sendMediaAsSticker is true */
         stickerCategories?: string[];
+        /** Sticker pack name, if sendMediaAsStickerPack is true */
+        stickerPackName?: string;
+        /** Sticker pack publisher, if sendMediaAsStickerPack is true */
+        stickerPackPublisher?: string;
+        /** Sticker pack id, if sendMediaAsStickerPack is true */
+        stickerPackId?: string;
+        /** Sticker pack tray icon; if omitted, WhatsApp uses the first sticker, if sendMediaAsStickerPack is true */
+        stickerPackTrayIcon?: MessageMedia | null;
         /** Should the bot send a quoted message without the quoted message if it fails to get the quote?
          * @default true (enabled) */
         ignoreQuoteErrors?: boolean;
@@ -1653,6 +1661,7 @@ declare namespace WAWebJS {
     export type MessageContent =
         | string
         | MessageMedia
+        | MessageMedia[]
         | Location
         | Poll
         | Contact

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     },
     "homepage": "https://wwebjs.dev/",
     "dependencies": {
+        "archiver": "7.0.1",
         "fluent-ffmpeg": "2.1.3",
         "mime": "3.0.0",
         "node-fetch": "2.7.0",
@@ -67,7 +68,6 @@
         "node": ">=18.0.0"
     },
     "optionalDependencies": {
-        "archiver": "7.0.1",
         "fs-extra": "11.3.4",
         "unzipper": "0.12.3"
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -1357,6 +1357,7 @@ class Client extends EventEmitter {
      * @property {boolean} [sendAudioAsVoice=false] - Send audio as voice message with a generated waveform
      * @property {boolean} [sendVideoAsGif=false] - Send video as gif
      * @property {boolean} [sendMediaAsSticker=false] - Send media as a sticker
+     * @property {boolean} [sendMediaAsStickerPack=false] - Send a MessageMedia array as a sticker pack
      * @property {boolean} [sendMediaAsDocument=false] - Send media as a document
      * @property {boolean} [sendMediaAsHd=false] - Send image as quality HD
      * @property {boolean} [isViewOnce=false] - Send photo/video as a view once message
@@ -1370,6 +1371,10 @@ class Client extends EventEmitter {
      * @property {string} [stickerAuthor=undefined] - Sets the author of the sticker, (if sendMediaAsSticker is true).
      * @property {string} [stickerName=undefined] - Sets the name of the sticker, (if sendMediaAsSticker is true).
      * @property {string[]} [stickerCategories=undefined] - Sets the categories of the sticker, (if sendMediaAsSticker is true). Provide emoji char array, can be null.
+     * @property {string} [stickerPackName=undefined] - Sets the name of the sticker pack, (if sendMediaAsStickerPack is true).
+     * @property {string} [stickerPackPublisher=undefined] - Sets the publisher of the sticker pack, (if sendMediaAsStickerPack is true).
+     * @property {string} [stickerPackId=undefined] - Sets the ID of the sticker pack, (if sendMediaAsStickerPack is true).
+     * @property {?MessageMedia} [stickerPackTrayIcon=undefined] - Sets the tray icon of the sticker pack; if omitted, WhatsApp uses the first sticker (if sendMediaAsStickerPack is true).
      * @property {boolean} [ignoreQuoteErrors = true] - Should the bot send a quoted message without the quoted message if it fails to get the quote?
      * @property {boolean} [waitUntilMsgSent = false] - Should the bot wait for the message send result?
      * @property {MessageMedia} [media] - Media to be sent
@@ -1379,7 +1384,7 @@ class Client extends EventEmitter {
     /**
      * Send a message to a specific chatId
      * @param {string} chatId
-     * @param {string|MessageMedia|Location|Poll|Contact|Array<Contact>|Buttons|List} content
+     * @param {string|MessageMedia|MessageMedia[]|Location|Poll|Contact|Array<Contact>|Buttons|List} content
      * @param {MessageSendOptions} [options] - Options used when sending the message
      *
      * @returns {Promise<Message>} Message that was just sent
@@ -1392,6 +1397,7 @@ class Client extends EventEmitter {
             isChannel &&
             [
                 options.sendMediaAsDocument,
+                options.sendMediaAsStickerPack,
                 options.quotedMessageId,
                 options.parseVCards,
                 options.isViewOnce,
@@ -1412,6 +1418,7 @@ class Client extends EventEmitter {
             isStatus &&
             [
                 options.sendMediaAsDocument,
+                options.sendMediaAsStickerPack,
                 options.quotedMessageId,
                 options.parseVCards,
                 options.isViewOnce,
@@ -1458,6 +1465,7 @@ class Client extends EventEmitter {
             sendAudioAsVoice: options.sendAudioAsVoice,
             sendVideoAsGif: options.sendVideoAsGif,
             sendMediaAsSticker: options.sendMediaAsSticker,
+            sendMediaAsStickerPack: options.sendMediaAsStickerPack,
             sendMediaAsDocument: options.sendMediaAsDocument,
             sendMediaAsHd: options.sendMediaAsHd,
             caption: options.caption,
@@ -1516,6 +1524,21 @@ class Client extends EventEmitter {
                 'Lists are now deprecated. See more at https://www.youtube.com/watch?v=hv1R1rLeVVE.',
             );
             internalOptions.list = content;
+            content = '';
+        }
+
+        if (internalOptions.sendMediaAsStickerPack) {
+            internalOptions.stickerPack = await Util.formatToWebpStickerPack(
+                content,
+                {
+                    name: options.stickerPackName,
+                    publisher: options.stickerPackPublisher,
+                    id: options.stickerPackId,
+                    categories: options.stickerCategories,
+                    trayIcon: options.stickerPackTrayIcon,
+                },
+                this.pupPage,
+            );
             content = '';
         }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -91,6 +91,7 @@ exports.MessageTypes = {
     VIDEO: 'video',
     DOCUMENT: 'document',
     STICKER: 'sticker',
+    STICKER_PACK: 'sticker-pack',
     LOCATION: 'location',
     CONTACT_CARD: 'vcard',
     CONTACT_CARD_MULTI: 'multi_vcard',

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -151,7 +151,14 @@ exports.LoadUtils = () => {
         const { findLink } = window.require('WALinkify');
 
         let mediaOptions = {};
-        if (options.media) {
+        if (options.stickerPack) {
+            mediaOptions = await window.WWebJS.processStickerPackData(
+                options.stickerPack,
+            );
+            content = undefined;
+            delete options.stickerPack;
+            delete options.sendMediaAsStickerPack;
+        } else if (options.media) {
             mediaOptions =
                 options.sendMediaAsSticker && !isChannel && !isStatus
                     ? await window.WWebJS.processStickerData(options.media)
@@ -678,6 +685,65 @@ exports.LoadUtils = () => {
         };
 
         return stickerInfo;
+    };
+
+    window.WWebJS.processStickerPackData = async (pack) => {
+        const file = window.WWebJS.mediaInfoToFile(pack.media);
+        const thumbnailFile = window.WWebJS.mediaInfoToFile(pack.thumbnail);
+        const filehash = await window.WWebJS.getFileHash(file);
+        const thumbnailSha256 = await window.WWebJS.getFileHash(thumbnailFile);
+
+        const upload = (blob, type, key) =>
+            window.require('WAWebUploadManager').encryptAndUpload({
+                blob,
+                type,
+                signal: new AbortController().signal,
+                // encryptAndUpload ignores a provided mediaKey on a fresh
+                // upload, but honors it together with a mediaKeyTimestamp
+                // (reupload semantics) so the thumbnail can share the pack key.
+                ...key,
+                uploadQpl: window
+                    .require('WAWebStartMediaUploadQpl')
+                    .startMediaUploadQpl({ entryPoint: 'MediaUpload' }),
+            });
+
+        // Upload the pack first; it mints its own mediaKey/timestamp. The
+        // sticker-pack message carries a single mediaKey (the pack's) and no
+        // separate thumbnail key, so the thumbnail is encrypted with that same
+        // key for the recipient to decrypt and render the chat card preview.
+        const uploaded = await upload(file, 'sticker-pack');
+        const thumbnail = await upload(
+            thumbnailFile,
+            'thumbnail-sticker-pack',
+            {
+                mediaKey: uploaded.mediaKey,
+                mediaKeyTimestamp: uploaded.mediaKeyTimestamp,
+            },
+        );
+
+        return {
+            directPath: uploaded.directPath,
+            encFilehash: uploaded.encFilehash,
+            filehash,
+            mediaKey: uploaded.mediaKey,
+            mediaKeyTimestamp: uploaded.mediaKeyTimestamp,
+            size: file.size,
+            type: 'sticker-pack',
+            filename: pack.stickerPackName,
+            stickerPackId: pack.stickerPackId,
+            name: pack.stickerPackName,
+            publisher: pack.stickerPackPublisher,
+            stickerPackPublisher: pack.stickerPackPublisher,
+            packDescription: pack.stickerPackDescription,
+            stickerPackSize: pack.stickerPackSize,
+            stickers: pack.stickers,
+            trayIconFileName: pack.trayIconFileName,
+            thumbnailDirectPath: thumbnail.directPath,
+            thumbnailEncSha256: thumbnail.encFilehash,
+            thumbnailSha256,
+            notifyName: window.require('WAWebConnModel').Conn.pushname || '',
+            messageSecret: window.crypto.getRandomValues(new Uint8Array(32)),
+        };
     };
 
     window.WWebJS.processMediaData = async (
@@ -1328,6 +1394,93 @@ exports.LoadUtils = () => {
             mimetype: options.mimetype,
             data: dataUrl.replace(`data:${options.mimetype};base64,`, ''),
         });
+    };
+
+    window.WWebJS.createStickerPackPreview = async (
+        mediaList,
+        options = {},
+    ) => {
+        if (!Array.isArray(mediaList) || !mediaList.length) {
+            throw new Error('Sticker pack preview requires media');
+        }
+
+        const { size, stickerSize, padding, mimetype, quality } = Object.assign(
+            {
+                size: 252,
+                stickerSize: 108,
+                padding: 12,
+                mimetype: 'image/jpeg',
+                quality: 0.79,
+            },
+            options,
+        );
+
+        const images = await Promise.all(
+            mediaList.slice(0, 4).map(
+                (media) =>
+                    new Promise((resolve, reject) => {
+                        const img = new Image();
+                        img.onload = () => resolve(img);
+                        img.onerror = reject;
+                        img.src = `data:${media.mimetype};base64,${media.data}`;
+                    }),
+            ),
+        );
+
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, size, size);
+
+        // WhatsApp layout: 108×108 stickers with 12px padding + 12px gap.
+        // The 1-sticker case is left-shifted by 10px and vertically centered.
+        const col0 = padding; // 12
+        const col1 = padding + stickerSize + padding; // 132
+        const row0 = padding; // 12
+        const row1 = padding + stickerSize + padding; // 132
+        const center = (size - stickerSize) / 2; // 72
+        const positions = {
+            1: [{ x: center + 10, y: center }],
+            2: [
+                { x: col0, y: center },
+                { x: col1, y: center },
+            ],
+            3: [
+                { x: col0, y: row0 },
+                { x: col1, y: row0 },
+                { x: center, y: row1 },
+            ],
+            4: [
+                { x: col0, y: row0 },
+                { x: col1, y: row0 },
+                { x: col0, y: row1 },
+                { x: col1, y: row1 },
+            ],
+        }[images.length];
+
+        images.forEach((img, i) => {
+            const ratio = Math.min(
+                stickerSize / img.width,
+                stickerSize / img.height,
+            );
+            const w = img.width * ratio;
+            const h = img.height * ratio;
+            const { x, y } = positions[i];
+            ctx.drawImage(
+                img,
+                x + (stickerSize - w) / 2,
+                y + (stickerSize - h) / 2,
+                w,
+                h,
+            );
+        });
+
+        const dataUrl = canvas.toDataURL(mimetype, quality);
+        return {
+            mimetype,
+            data: dataUrl.replace(`data:${mimetype};base64,`, ''),
+        };
     };
 
     window.WWebJS.setPicture = async (chatId, media) => {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -3,9 +3,12 @@
 const path = require('path');
 const Crypto = require('crypto');
 const { tmpdir } = require('os');
+const { PassThrough } = require('stream');
+const archiver = require('archiver');
 const ffmpeg = require('fluent-ffmpeg');
 const webp = require('node-webpmux');
 const fs = require('fs').promises;
+const MessageMedia = require('../structures/MessageMedia');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 
 /**
@@ -150,41 +153,257 @@ class Util {
      * @returns {Promise<MessageMedia>} media in webp format
      */
     static async formatToWebpSticker(media, metadata, pupPage) {
-        let webpMedia;
-
-        if (media.mimetype.includes('image'))
-            webpMedia = await this.formatImageToWebpSticker(media, pupPage);
-        else if (media.mimetype.includes('video'))
-            webpMedia = await this.formatVideoToWebpSticker(media);
-        else throw new Error('Invalid media format');
+        const webpMedia = await this._mediaToWebp(media, pupPage);
 
         if (metadata.name || metadata.author) {
-            const img = new webp.Image();
-            const hash = this.generateHash(32);
-            const stickerPackId = hash;
-            const packname = metadata.name;
-            const author = metadata.author;
-            const categories = metadata.categories || [''];
-            const json = {
-                'sticker-pack-id': stickerPackId,
-                'sticker-pack-name': packname,
-                'sticker-pack-publisher': author,
-                emojis: categories,
-            };
-            let exifAttr = Buffer.from([
-                0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
-                0x41, 0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00,
-                0x00, 0x00,
-            ]);
-            let jsonBuffer = Buffer.from(JSON.stringify(json), 'utf8');
-            let exif = Buffer.concat([exifAttr, jsonBuffer]);
-            exif.writeUIntLE(jsonBuffer.length, 14, 4);
-            await img.load(Buffer.from(webpMedia.data, 'base64'));
-            img.exif = exif;
-            webpMedia.data = (await img.save(null)).toString('base64');
+            const buffer = await this._writeStickerExif(
+                Buffer.from(webpMedia.data, 'base64'),
+                {
+                    'sticker-pack-id': this.generateHash(32),
+                    'sticker-pack-name': metadata.name,
+                    'sticker-pack-publisher': metadata.author,
+                    emojis: metadata.categories || [''],
+                },
+            );
+            webpMedia.data = buffer.toString('base64');
         }
 
         return webpMedia;
+    }
+
+    /**
+     * Converts an image or video media into a webp sticker.
+     * @param {MessageMedia} media
+     * @param {import('puppeteer').Page} pupPage
+     * @returns {Promise<MessageMedia>} media in webp format
+     * @private
+     */
+    static async _mediaToWebp(media, pupPage) {
+        if (media.mimetype.includes('image'))
+            return this.formatImageToWebpSticker(media, pupPage);
+        if (media.mimetype.includes('video'))
+            return this.formatVideoToWebpSticker(media);
+        throw new Error('Invalid media format');
+    }
+
+    /**
+     * Writes WhatsApp sticker EXIF metadata (a JSON blob) into a webp buffer.
+     * @param {Buffer} buffer raw webp data
+     * @param {Object} json metadata written into the EXIF chunk
+     * @returns {Promise<Buffer>} webp buffer with the EXIF chunk applied
+     * @private
+     */
+    static async _writeStickerExif(buffer, json) {
+        const exifAttr = Buffer.from([
+            0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x41,
+            0x57, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00,
+        ]);
+        const jsonBuffer = Buffer.from(JSON.stringify(json), 'utf8');
+        const exif = Buffer.concat([exifAttr, jsonBuffer]);
+        exif.writeUIntLE(jsonBuffer.length, 14, 4);
+
+        const img = new webp.Image();
+        await img.load(buffer);
+        img.exif = exif;
+        return img.save(null);
+    }
+
+    /**
+     * Reads sticker EXIF metadata and the animation flag from a webp buffer.
+     * @param {Buffer} buffer
+     * @returns {Promise<{metadata: Object|null, isAnimated: boolean}>}
+     * @private
+     */
+    static async _inspectWebpSticker(buffer) {
+        const img = new webp.Image();
+        await img.load(buffer);
+
+        let metadata = null;
+        if (img.exif) {
+            const text = img.exif.toString('utf8');
+            const start = text.indexOf('{');
+            if (start !== -1) {
+                try {
+                    metadata = JSON.parse(text.slice(start));
+                } catch (ignoredError) {
+                    metadata = null;
+                }
+            }
+        }
+
+        return { metadata, isAnimated: Boolean(img.anim?.frames?.length) };
+    }
+
+    /**
+     * Zips the given named buffers into a single zip buffer.
+     * @param {{name: string, buffer: Buffer}[]} entries
+     * @returns {Promise<Buffer>}
+     * @private
+     */
+    static _zip(entries) {
+        return new Promise((resolve, reject) => {
+            const archive = archiver('zip', { zlib: { level: 9 } });
+            const stream = new PassThrough();
+            const chunks = [];
+
+            stream.on('data', (chunk) => chunks.push(chunk));
+            stream.on('end', () => resolve(Buffer.concat(chunks)));
+            stream.on('error', reject);
+            archive.on('error', reject);
+            archive.on('warning', reject);
+
+            archive.pipe(stream);
+            entries.forEach(({ name, buffer }) =>
+                archive.append(buffer, { name }),
+            );
+            archive.finalize();
+        });
+    }
+
+    /**
+     * Formats an array of media into a native sticker pack payload.
+     * @param {MessageMedia[]} mediaList
+     * @param {Object} metadata
+     * @param {string} metadata.name - sticker pack name (required)
+     * @param {string} [metadata.publisher]
+     * @param {string} [metadata.id] - defaults to a random UUID
+     * @param {string[]} [metadata.categories] - emoji categories applied to every sticker
+     * @param {?MessageMedia} [metadata.trayIcon] - image used as the tray icon; defaults to the first sticker
+     * @param {import('puppeteer').Page} pupPage
+     * @returns {Promise<Object>} sticker pack payload consumed by the injected uploader
+     */
+    static async formatToWebpStickerPack(mediaList, metadata, pupPage) {
+        if (!Array.isArray(mediaList) || mediaList.length === 0) {
+            throw new Error(
+                'sendMediaAsStickerPack requires a non-empty array of MessageMedia',
+            );
+        }
+        if (mediaList.some((media) => !(media instanceof MessageMedia))) {
+            throw new Error(
+                'sendMediaAsStickerPack requires a non-empty array of MessageMedia',
+            );
+        }
+
+        const name = (metadata.name || '').trim();
+        if (!name) throw new Error('stickerPackName is required');
+
+        if (metadata.trayIcon != null) {
+            if (!(metadata.trayIcon instanceof MessageMedia))
+                throw new Error(
+                    'Sticker pack tray icon must be a MessageMedia',
+                );
+            if (!metadata.trayIcon.mimetype.includes('image'))
+                throw new Error('Sticker pack tray icon must be an image');
+        }
+
+        const id = metadata.id || Crypto.randomUUID();
+        const publisher = metadata.publisher || '';
+        const categories = Array.isArray(metadata.categories)
+            ? metadata.categories
+            : undefined;
+        const trayIconFileName = `${id}.png`;
+
+        const stickers = [];
+        for (const media of mediaList) {
+            const webpMedia = await this._mediaToWebp(media, pupPage);
+            const source = Buffer.from(webpMedia.data, 'base64');
+            const { metadata: original, isAnimated } =
+                await this._inspectWebpSticker(source);
+
+            const emojis =
+                categories ||
+                (Array.isArray(original?.emojis) ? original.emojis : undefined);
+            const json = {
+                'sticker-pack-id': id,
+                'sticker-pack-name': name,
+                'sticker-pack-publisher': publisher,
+            };
+            if (Array.isArray(emojis)) json.emojis = emojis;
+            json['is-from-user-created-pack'] = 1;
+
+            const buffer = await this._writeStickerExif(source, json);
+            const fileName = `${Crypto.createHash('sha256')
+                .update(buffer)
+                .digest('base64')
+                .replace(/\//g, '-')}.webp`;
+
+            stickers.push({
+                buffer,
+                fileName,
+                emojis: emojis || [],
+                isAnimated,
+                isLottie: false,
+                mimetype: 'image/webp',
+                accessibilityLabel: '',
+            });
+        }
+
+        const crop = (media, options) =>
+            pupPage.evaluate(
+                (m, o) => window.WWebJS.cropAndResizeImage(m, o),
+                media,
+                options,
+            );
+        const asMediaInfo = (sticker) => ({
+            mimetype: 'image/webp',
+            data: sticker.buffer.toString('base64'),
+            filename: sticker.fileName,
+        });
+
+        const trayIcon = await crop(
+            metadata.trayIcon || asMediaInfo(stickers[0]),
+            {
+                mimetype: 'image/png',
+                size: 64,
+            },
+        );
+        trayIcon.filename = trayIconFileName;
+
+        const thumbnail = await pupPage.evaluate(
+            (medias, o) => window.WWebJS.createStickerPackPreview(medias, o),
+            stickers.map(asMediaInfo),
+            { mimetype: 'image/jpeg', size: 252, quality: 0.79 },
+        );
+        thumbnail.filename = `${id}.jpg`;
+
+        const trayIconBuffer = Buffer.from(trayIcon.data, 'base64');
+        const thumbnailBuffer = Buffer.from(thumbnail.data, 'base64');
+        const stickerPackSize =
+            trayIconBuffer.length +
+            stickers.reduce((total, s) => total + s.buffer.length, 0);
+        const zipBuffer = await this._zip([
+            ...stickers.map((s) => ({ name: s.fileName, buffer: s.buffer })),
+            { name: trayIconFileName, buffer: trayIconBuffer },
+        ]);
+
+        return {
+            media: new MessageMedia(
+                'application/zip',
+                zipBuffer.toString('base64'),
+                name,
+                zipBuffer.length,
+            ),
+            thumbnail: new MessageMedia(
+                'image/jpeg',
+                thumbnail.data,
+                thumbnail.filename,
+                thumbnailBuffer.length,
+            ),
+            stickerPackId: id,
+            stickerPackName: name,
+            stickerPackPublisher: publisher,
+            stickerPackDescription: '',
+            stickerPackSize,
+            trayIconFileName,
+            stickers: stickers.map((s) => ({
+                fileName: s.fileName,
+                emojis: s.emojis,
+                isLottie: s.isLottie,
+                mimetype: s.mimetype,
+                isAnimated: s.isAnimated,
+                accessibilityLabel: s.accessibilityLabel,
+            })),
+        };
     }
 
     /**


### PR DESCRIPTION
## Description

Adds support for sending a native sticker pack via `sendMessage`. Pass a `MessageMedia[]` array with `sendMediaAsStickerPack: true` and the library will:

1. Convert each media item to a WebP sticker (image or video)
2. Embed per-sticker EXIF metadata (pack id, name, publisher, emoji categories)
3. Pack everything into a zip with a tray icon (defaults to the first sticker, or a custom image via `stickerPackTrayIcon`)
4. Generate an auto-generated 2×2 grid chat-card thumbnail using a new browser-side canvas utility
5. Upload the zip and thumbnail to WhatsApp's CDN (thumbnail is re-encrypted with the pack's media key so the recipient can render the preview)
6. Send the message as a native `sticker-pack` type

<img width="350" alt="image" src="https://github.com/user-attachments/assets/07ca8e44-cf4c-4d8b-ab35-c90d5f7b79bf" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/8db4e3d3-b3bc-440c-92ea-b33a927a9e33" />


**New `sendMessage` options:**

| Option | Type | Description |
|---|---|---|
| `sendMediaAsStickerPack` | `boolean` | Send a `MessageMedia[]` as a sticker pack |
| `stickerPackName` | `string` | Pack name (required) |
| `stickerPackPublisher` | `string` | Publisher name |
| `stickerPackId` | `string` | Pack ID (defaults to a random UUID) |
| `stickerPackTrayIcon` | `MessageMedia \| null` | Custom tray icon; defaults to the first sticker |

**Internal refactor:** the pre-existing `formatToWebpSticker` single-sticker path now shares the new `_writeStickerExif`, `_mediaToWebp`, and `_inspectWebpSticker` helpers, eliminating duplicated EXIF-building code.

## Related Issue(s)

#3614 3614

## Testing Summary

### Test Details

- Sent sticker packs of 1, 2, 3, and 4+ stickers from images and verified they install and display correctly in WhatsApp on both sender and receiver sides.
- Verified the auto-generated 2×2 grid thumbnail renders correctly in the chat card preview.
- Verified the custom tray icon option (`stickerPackTrayIcon`) replaces the default first-sticker icon.
- Ran `npm test` — all existing tests pass.

### Environment

- Machine OS: Windows 11

- Phone OS:

- Library Version: 1.34.7

- WhatsApp Web Version: 2.3000.1041450038

- Browser Type and Version: Chrome 149.0.7827

- Node Version: 26.2.0

## Type of Change

- [x] **Dependency change** _(archiver moved from `optionalDependencies` to `dependencies`)_
- [ ] **Bug fix**
- [x] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change**
- [ ] **Non-code change**

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.