### PR TITLE
fix: setStatus method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,9 +244,15 @@ declare namespace WAWebJS {
 
         /**
          * Sets the current user's status message
-         * @param status New status message
+         * @param {string} status New status message
+         * @param {string} emoji New emoji to status
+         * @param {number} duration seconds for status duration
          */
-        setStatus(status: string): Promise<void>;
+        setStatus(
+            status: string,
+            emoji: string,
+            duration: number,
+        ): Promise<boolean>;
 
         /**
          * Sets the current user's display name

--- a/index.d.ts
+++ b/index.d.ts
@@ -244,16 +244,9 @@ declare namespace WAWebJS {
 
         /**
          * Sets the current user's status message
-         * @param {string} status New status message
-         * @param {string} emoji New emoji to status
-         * @param {number} duration seconds for status duration
+         * @param status New status message
          */
-        setStatus(
-            status: string,
-            emoji: string,
-            duration: number,
-        ): Promise<boolean>;
-
+        setStatus(status: string): Promise<void>;
         /**
          * Sets the current user's display name
          * @param displayName New display name

--- a/src/Client.js
+++ b/src/Client.js
@@ -1941,13 +1941,22 @@ class Client extends EventEmitter {
     /**
      * Sets the current user's status message
      * @param {string} status New status message
+     * @param {string} emoji New emoji to status
+     * @param {number} duration seconds for status duration
      */
-    async setStatus(status) {
-        await this.pupPage.evaluate(async (status) => {
-            return await window
-                .require('WAWebContactStatusBridge')
-                .setMyStatus(status);
-        }, status);
+    async setStatus(status, emoji, duration) {
+        return await this.pupPage.evaluate(
+            async (status, emoji, duration) => {
+                const res = await window
+                    .require('WAWebUpdateTextStatusJob')
+                    .updateTextStatus(status, emoji, duration);
+
+                return res && res.result === 'SUCCESS';
+            },
+            status,
+            emoji,
+            duration,
+        );
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -2000,22 +2000,13 @@ class Client extends EventEmitter {
     /**
      * Sets the current user's status message
      * @param {string} status New status message
-     * @param {string} emoji New emoji to status
-     * @param {number} duration seconds for status duration
      */
     async setStatus(status, emoji, duration) {
-        return await this.pupPage.evaluate(
-            async (status, emoji, duration) => {
-                const res = await window
-                    .require('WAWebUpdateTextStatusJob')
-                    .updateTextStatus(status, emoji, duration);
-
-                return res && res.result === 'SUCCESS';
-            },
-            status,
-            emoji,
-            duration,
-        );
+        await this.pupPage.evaluate(async (status) => {
+            return await window
+                .require('WAWebContactStatusBridge')
+                .setMyStatus(status);
+        }, status);
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -2001,7 +2001,7 @@ class Client extends EventEmitter {
      * Sets the current user's status message
      * @param {string} status New status message
      */
-    async setStatus(status, emoji, duration) {
+    async setStatus(status) {
         await this.pupPage.evaluate(async (status) => {
             return await window
                 .require('WAWebContactStatusBridge')


### PR DESCRIPTION
## Description

Fixing method setStatus, adding new params emoji, and duration.

## Testing Summary

### Test Details

```
client.on('ready', async () => {
    await client.setStatus('My new status', '😁', 172800);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix_set_status`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix_set_status`

### Environment

- Machine OS:

Windows 10

- Phone OS:

Android 11

- Library Version:

1.34.7

- WhatsApp Web Version:

2.3000.1041831138

- Browser Type and Version:

Chrome 149.0.7827.156

- Node Version:

18.20.2

## Type of Change

<!-- Select all that apply: -->

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [X] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

<!-- Please confirm that all relevant items below have been completed. -->

- [X] My code follows the style guidelines of this project.
- [X] All new and existing tests pass (`npm test`).
- [X] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [X] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
