### PR TITLE
fix: msg.avParams is not a function when sending media

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -515,7 +515,9 @@ exports.LoadUtils = () => {
                     newsletterJid: chat.id.toJid(),
                     ...(isMedia
                         ? {
-                              mediaMetadata: msg.avParams(),
+                              mediaMetadata: window
+                                  .require('WAWebMediaMetadata')
+                                  .mediaMetadata(msg),
                               mediaHandle: isMedia
                                   ? mediaOptions.mediaHandle
                                   : null,


### PR DESCRIPTION
fix: msg.avParams is not a function when sending media
`avParams()` was just an shortcut for `mediaMedata(msg)`
fix #201823