### PR TITLE
feat: add call answering, outgoing calls and audio injection

### DIFF
--- a/example.js
+++ b/example.js
@@ -697,7 +697,24 @@ client.on('call', async (call) => {
         call.from,
         `[${call.fromMe ? 'Outgoing' : 'Incoming'}] Phone call from ${call.from}, type ${call.isGroup ? 'group' : ''} ${call.isVideo ? 'video' : 'audio'} call. ${rejectCalls ? 'This call was automatically rejected by the script.' : ''}`,
     );
+
+    // Instead of rejecting, a call can also be answered and an audio clip
+    // (e.g. a text-to-speech file you generated) can be played into it:
+    // await call.accept(); // answers with audio only, even for video calls
+    // await call.playAudio(MessageMedia.fromFilePath('./welcome.mp3'));
+    // await call.end();
 });
+
+// Placing an outgoing call and speaking once the other party answers:
+// const call = await client.call('1234567890', { waitForAnswer: true });
+// if (await call.isConnected()) {
+//     await call.playAudio(MessageMedia.fromFilePath('./message.mp3'));
+//     await call.end();
+// }
+
+// Checking for an ongoing call and hanging it up:
+// const activeCall = await client.getActiveCall();
+// if (activeCall) await activeCall.end();
 
 client.on('disconnected', (reason) => {
     console.log('Client was logged out', reason);

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,10 +212,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
@@ -344,6 +341,19 @@ declare namespace WAWebJS {
 
         /** Generates a WhatsApp call link (video call or voice call) */
         createCallLink(startTime: Date, callType: string): Promise<string>;
+
+        /** Places an outgoing call to the provided chat or phone number */
+        call(
+            chatId: string,
+            options?: {
+                video?: boolean;
+                waitForAnswer?: boolean;
+                answerTimeout?: number;
+            },
+        ): Promise<Call>;
+
+        /** Gets the call that is currently ongoing (ringing, being placed or connected), if any */
+        getActiveCall(): Promise<Call | null>;
 
         /**
          * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
@@ -2444,6 +2454,18 @@ declare namespace WAWebJS {
 
         /** Reject the call */
         reject: () => Promise<void>;
+
+        /** Accept the call (audio only by default, even for incoming video calls) */
+        accept: (options?: { video?: boolean }) => Promise<boolean>;
+
+        /** End an ongoing call */
+        end: () => Promise<boolean>;
+
+        /** Play an audio clip into the ongoing call so the other party can hear it */
+        playAudio: (media: MessageMedia | string) => Promise<number>;
+
+        /** Indicates whether the call is currently connected (the other party has answered) */
+        isConnected: () => Promise<boolean>;
     }
 
     /** Message type List */

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,6 +349,7 @@ declare namespace WAWebJS {
                 video?: boolean;
                 waitForAnswer?: boolean;
                 answerTimeout?: number;
+                injectAudio?: boolean;
             },
         ): Promise<Call>;
 
@@ -2456,7 +2457,10 @@ declare namespace WAWebJS {
         reject: () => Promise<void>;
 
         /** Accept the call (audio only by default, even for incoming video calls) */
-        accept: (options?: { video?: boolean }) => Promise<boolean>;
+        accept: (options?: {
+            video?: boolean;
+            injectAudio?: boolean;
+        }) => Promise<boolean>;
 
         /** End an ongoing call */
         end: () => Promise<boolean>;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1172,7 +1172,18 @@ class Client extends EventEmitter {
                 if (!window._wwjsCallListener) {
                     window._wwjsCallListener = true;
                     WAWebCallCollection.on('change:activeCall', (call) => {
-                        emitCall(call);
+                        if (call) {
+                            emitCall(call);
+                        }
+                        // Restore the real microphone once the call is over so a
+                        // following normal call is not fed the injected stream.
+                        if (
+                            !call ||
+                            (typeof call.getState === 'function' &&
+                                call.getState() === 0)
+                        ) {
+                            window.WWebJS.teardownCallMediaStream?.();
+                        }
                     });
                 }
 
@@ -3325,22 +3336,25 @@ class Client extends EventEmitter {
      * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
      * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
      * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via Call.playAudio) instead of the real microphone. Set false to place a normal call
      * @returns {Promise<Call>} The placed call
      */
     async call(chatId, options = {}) {
         const callData = await this.pupPage.evaluate(
-            (id, isVideo, waitForAnswer, answerTimeout) => {
+            (id, isVideo, waitForAnswer, answerTimeout, injectAudio) => {
                 return window.WWebJS.startCall(
                     id,
                     isVideo,
                     waitForAnswer,
                     answerTimeout,
+                    injectAudio,
                 );
             },
             chatId,
             options.video ?? false,
             options.waitForAnswer ?? false,
             options.answerTimeout ?? 60000,
+            options.injectAudio ?? true,
         );
 
         return new Call(this, callData);

--- a/src/Client.js
+++ b/src/Client.js
@@ -499,6 +499,19 @@ class Client extends EventEmitter {
             // navigator.webdriver fix
             browserArgs.push('--disable-blink-features=AutomationControlled');
 
+            // Required for the calling feature: allow the audio graph to run
+            // without a user gesture and auto-grant the microphone permission.
+            const callArgs = [
+                '--autoplay-policy=no-user-gesture-required',
+                '--use-fake-ui-for-media-stream',
+            ];
+            for (const arg of callArgs) {
+                const flag = arg.split('=')[0];
+                if (!browserArgs.find((a) => a.startsWith(flag))) {
+                    browserArgs.push(arg);
+                }
+            }
+
             browser = await puppeteer.launch({
                 ...puppeteerOpts,
                 args: browserArgs,
@@ -1131,26 +1144,52 @@ class Client extends EventEmitter {
                 WAWebCallCollection &&
                 typeof WAWebCallCollection.on === 'function'
             ) {
+                const emitCall = (call) => {
+                    if (
+                        !call ||
+                        !call.id ||
+                        window._wwjsLastCallId === call.id
+                    ) {
+                        return;
+                    }
+                    window._wwjsLastCallId = call.id;
+                    window.onIncomingCall({
+                        id: call.id,
+                        peerJid: call.peerJid,
+                        isVideo: call.isVideo,
+                        isGroup: call.isGroup,
+                        canHandleLocally: call.canHandleLocally,
+                        outgoing: call.outgoing,
+                        webClientShouldHandle: call.webClientShouldHandle,
+                        participants: call.participants,
+                    });
+                };
+
+                // Newer WhatsApp Web surfaces calls through the collection's
+                // activeCall attribute instead of inserting them into the map.
+                // The changed call is passed as the handler argument; the
+                // lastActiveCall getter is not yet updated at this point.
+                if (!window._wwjsCallListener) {
+                    window._wwjsCallListener = true;
+                    WAWebCallCollection.on('change:activeCall', (call) => {
+                        emitCall(call);
+                    });
+                }
+
+                // Fallback for versions that still populate the internal map.
                 const mapKey = Object.keys(WAWebCallCollection).find(
                     (k) => WAWebCallCollection[k] instanceof Map,
                 );
-                const internalCallMap = WAWebCallCollection[mapKey];
-                const originalMapSet =
-                    internalCallMap.set.bind(internalCallMap);
+                if (mapKey) {
+                    const internalCallMap = WAWebCallCollection[mapKey];
+                    const originalMapSet =
+                        internalCallMap.set.bind(internalCallMap);
 
-                internalCallMap.set = function (key, value) {
-                    window.onIncomingCall({
-                        id: value.id,
-                        peerJid: value.peerJid,
-                        isVideo: value.isVideo,
-                        isGroup: value.isGroup,
-                        canHandleLocally: value.canHandleLocally,
-                        outgoing: value.outgoing,
-                        webClientShouldHandle: value.webClientShouldHandle,
-                        participants: value.participants,
-                    });
-                    return originalMapSet(key, value);
-                };
+                    internalCallMap.set = function (key, value) {
+                        emitCall(value);
+                        return originalMapSet(key, value);
+                    };
+                }
             }
             Chat.on('remove', async (chat) => {
                 window.onRemoveChatEvent(
@@ -3277,6 +3316,46 @@ class Client extends EventEmitter {
             startTime,
             callType,
         );
+    }
+
+    /**
+     * Places an outgoing call to the provided chat or phone number
+     * @param {string} chatId The chat ID ("@c.us" is automatically appended) or phone number to call
+     * @param {object} [options] Call options
+     * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
+     * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
+     * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @returns {Promise<Call>} The placed call
+     */
+    async call(chatId, options = {}) {
+        const callData = await this.pupPage.evaluate(
+            (id, isVideo, waitForAnswer, answerTimeout) => {
+                return window.WWebJS.startCall(
+                    id,
+                    isVideo,
+                    waitForAnswer,
+                    answerTimeout,
+                );
+            },
+            chatId,
+            options.video ?? false,
+            options.waitForAnswer ?? false,
+            options.answerTimeout ?? 60000,
+        );
+
+        return new Call(this, callData);
+    }
+
+    /**
+     * Gets the call that is currently ongoing (ringing, being placed or connected), if any
+     * @returns {Promise<Call|null>} The current call, or null if there is no ongoing call
+     */
+    async getActiveCall() {
+        const callData = await this.pupPage.evaluate(() => {
+            return window.WWebJS.getActiveCall();
+        });
+
+        return callData ? new Call(this, callData) : null;
     }
 
     /**

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -80,15 +80,17 @@ class Call extends Base {
      * Accept the call
      * @param {object} [options] Accept options
      * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via playAudio) instead of the real microphone. Set false to answer with the real microphone
      * @returns {Promise<boolean>}
      */
     async accept(options = {}) {
         return this.client.pupPage.evaluate(
-            (id, isVideo) => {
-                return window.WWebJS.acceptCall(id, isVideo);
+            (id, isVideo, injectAudio) => {
+                return window.WWebJS.acceptCall(id, isVideo, injectAudio);
             },
             this.id,
             options.video ?? false,
+            options.injectAudio ?? true,
         );
     }
 

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -75,6 +75,54 @@ class Call extends Base {
             this.id,
         );
     }
+
+    /**
+     * Accept the call
+     * @param {object} [options] Accept options
+     * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @returns {Promise<boolean>}
+     */
+    async accept(options = {}) {
+        return this.client.pupPage.evaluate(
+            (id, isVideo) => {
+                return window.WWebJS.acceptCall(id, isVideo);
+            },
+            this.id,
+            options.video ?? false,
+        );
+    }
+
+    /**
+     * End an ongoing call
+     * @returns {Promise<boolean>}
+     */
+    async end() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.endCall(id);
+        }, this.id);
+    }
+
+    /**
+     * Play an audio clip into the ongoing call so the other party can hear it
+     * @param {MessageMedia|string} media A MessageMedia instance or a base64 encoded audio string
+     * @returns {Promise<number>} The duration of the played audio in seconds
+     */
+    async playAudio(media) {
+        const data = typeof media === 'string' ? media : media.data;
+        return this.client.pupPage.evaluate((base64) => {
+            return window.WWebJS.playCallAudio(base64);
+        }, data);
+    }
+
+    /**
+     * Indicates whether the call is currently connected (the other party has answered)
+     * @returns {Promise<boolean>}
+     */
+    async isConnected() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.isCallConnected(id);
+        }, this.id);
+    }
 }
 
 module.exports = Call;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1357,6 +1357,11 @@ exports.LoadUtils = () => {
 
     window.WWebJS.setupCallMediaStream = () => {
         const store = window.WWebJS;
+        // Route the outgoing microphone through our own graph only while an
+        // injected call is active, so ordinary calls keep using the real
+        // microphone (see teardownCallMediaStream).
+        store._callMediaActive = true;
+
         if (store._callMedia && store._callMedia.context.state !== 'closed') {
             return store._callMedia;
         }
@@ -1371,7 +1376,8 @@ exports.LoadUtils = () => {
 
         // WhatsApp acquires the microphone through this single entry point.
         // Patch it once so the outgoing audio track is fed from our own graph
-        // instead of a physical device. A fresh destination is handed out on
+        // instead of a physical device, but only while injection is active so
+        // normal calls are left untouched. A fresh destination is handed out on
         // every call because WhatsApp stops the track when the stream is
         // disposed, which would permanently silence a shared destination.
         const mediaModule = window.require('WAGetUserMedia');
@@ -1380,7 +1386,11 @@ exports.LoadUtils = () => {
             mediaModule._wwebjsPatched = true;
             mediaModule.getUserMedia = (constraints) => {
                 const media = window.WWebJS._callMedia;
-                if ((constraints && constraints.video) || !media) {
+                if (
+                    (constraints && constraints.video) ||
+                    !media ||
+                    !window.WWebJS._callMediaActive
+                ) {
                     return original(constraints);
                 }
                 const destination =
@@ -1392,6 +1402,23 @@ exports.LoadUtils = () => {
         }
 
         return store._callMedia;
+    };
+
+    window.WWebJS.teardownCallMediaStream = () => {
+        const media = window.WWebJS._callMedia;
+        window.WWebJS._callMediaActive = false;
+        if (!media) return;
+
+        // Detach the destinations handed out during the call so the next call
+        // starts from a clean graph and the real microphone is used again.
+        for (const destination of media.destinations) {
+            try {
+                media.master.disconnect(destination);
+            } catch {
+                // The destination was already disconnected by WhatsApp.
+            }
+        }
+        media.destinations = [];
     };
 
     window.WWebJS.playCallAudio = async (base64) => {
@@ -1417,8 +1444,14 @@ exports.LoadUtils = () => {
         });
     };
 
-    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
-        window.WWebJS.setupCallMediaStream();
+    window.WWebJS.acceptCall = async (
+        callId,
+        isVideo = false,
+        injectAudio = true,
+    ) => {
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
         const stack = await window.WWebJS.getCallStackInterface();
         await stack.acceptCall(callId, isVideo);
         return true;
@@ -1430,6 +1463,7 @@ exports.LoadUtils = () => {
             'WAWebWamEnumCallTermReason',
         );
         await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        window.WWebJS.teardownCallMediaStream();
         return true;
     };
 
@@ -1438,8 +1472,11 @@ exports.LoadUtils = () => {
         isVideo = false,
         waitForAnswer = false,
         timeout = 60000,
+        injectAudio = true,
     ) => {
-        window.WWebJS.setupCallMediaStream();
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
 
         let wid;
         const target = String(chatId);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1320,6 +1320,13 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        if (stack && typeof stack.rejectCall === 'function') {
+            await stack.rejectCall();
+            return;
+        }
+
+        // Fallback signaling stanza for older WhatsApp Web builds.
         let userId = window
             .require('WAWebUserPrefsMeUser')
             .getMaybeMePnUser()._serialized;
@@ -1340,6 +1347,181 @@ exports.LoadUtils = () => {
             ],
         );
         await window.require('WADeprecatedSendIq').deprecatedCastStanza(stanza);
+    };
+
+    window.WWebJS.getCallStackInterface = async () => {
+        return window
+            .require('WAWebVoipStackInterface')
+            .getVoipStackInterface();
+    };
+
+    window.WWebJS.setupCallMediaStream = () => {
+        const store = window.WWebJS;
+        if (store._callMedia && store._callMedia.context.state !== 'closed') {
+            return store._callMedia;
+        }
+
+        const AudioContextClass =
+            window.AudioContext || window.webkitAudioContext;
+        const context = new AudioContextClass();
+        const master = context.createGain();
+        master.gain.value = 1;
+
+        store._callMedia = { context, master, destinations: [] };
+
+        // WhatsApp acquires the microphone through this single entry point.
+        // Patch it once so the outgoing audio track is fed from our own graph
+        // instead of a physical device. A fresh destination is handed out on
+        // every call because WhatsApp stops the track when the stream is
+        // disposed, which would permanently silence a shared destination.
+        const mediaModule = window.require('WAGetUserMedia');
+        if (!mediaModule._wwebjsPatched) {
+            const original = mediaModule.getUserMedia;
+            mediaModule._wwebjsPatched = true;
+            mediaModule.getUserMedia = (constraints) => {
+                const media = window.WWebJS._callMedia;
+                if ((constraints && constraints.video) || !media) {
+                    return original(constraints);
+                }
+                const destination =
+                    media.context.createMediaStreamDestination();
+                media.master.connect(destination);
+                media.destinations.push(destination);
+                return Promise.resolve(destination.stream);
+            };
+        }
+
+        return store._callMedia;
+    };
+
+    window.WWebJS.playCallAudio = async (base64) => {
+        const { context, master } = window.WWebJS.setupCallMediaStream();
+        if (context.state === 'suspended') {
+            await context.resume();
+        }
+
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+
+        const buffer = await context.decodeAudioData(bytes.buffer);
+        const source = context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(master);
+
+        return new Promise((resolve) => {
+            source.onended = () => resolve(buffer.duration);
+            source.start();
+        });
+    };
+
+    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
+        window.WWebJS.setupCallMediaStream();
+        const stack = await window.WWebJS.getCallStackInterface();
+        await stack.acceptCall(callId, isVideo);
+        return true;
+    };
+
+    window.WWebJS.endCall = async (callId) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        const { CALL_TERM_REASON } = window.require(
+            'WAWebWamEnumCallTermReason',
+        );
+        await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        return true;
+    };
+
+    window.WWebJS.startCall = async (
+        chatId,
+        isVideo = false,
+        waitForAnswer = false,
+        timeout = 60000,
+    ) => {
+        window.WWebJS.setupCallMediaStream();
+
+        let wid;
+        const target = String(chatId);
+        if (target.includes('@')) {
+            wid = window.require('WAWebWidFactory').createWid(target);
+        } else {
+            const result = await window
+                .require('WAWebQueryExistsJob')
+                .queryPhoneExists('+' + target.replace(/\D/g, ''));
+            if (!result || !result.wid) {
+                throw new Error(
+                    'The provided phone number is not registered on WhatsApp',
+                );
+            }
+            wid = result.wid;
+        }
+
+        const { CALL_FROM_UI } = window.require('WAWebWamEnumCallFromUi');
+        await window
+            .require('WAWebVoipStartCall')
+            .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
+
+        // The call is registered in the collection shortly after the offer is
+        // sent, so wait for it to become available before returning its data.
+        const collection = window.require('WAWebCallCollection');
+        let call = collection.lastActiveCall;
+        for (let i = 0; i < 30 && !call; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            call = collection.lastActiveCall;
+        }
+
+        // Optionally block until the callee answers (or the timeout elapses).
+        if (call && waitForAnswer) {
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {
+                if (
+                    collection.isInConnectedCall &&
+                    collection.lastActiveCall &&
+                    collection.lastActiveCall.id === call.id
+                ) {
+                    break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 200));
+            }
+        }
+
+        return call
+            ? {
+                  id: call.id,
+                  peerJid: call.peerJid?._serialized,
+                  isVideo: call.isVideo,
+                  isGroup: call.isGroup,
+                  outgoing: call.outgoing,
+              }
+            : null;
+    };
+
+    window.WWebJS.isCallConnected = (callId) => {
+        const collection = window.require('WAWebCallCollection');
+        return (
+            collection.isInConnectedCall === true &&
+            !!collection.lastActiveCall &&
+            collection.lastActiveCall.id === callId
+        );
+    };
+
+    window.WWebJS.getActiveCall = () => {
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return {
+            id: call.id,
+            peerJid: call.peerJid?._serialized,
+            offerTime: call.offerTime,
+            isVideo: call.isVideo,
+            isGroup: call.isGroup,
+            outgoing: call.outgoing,
+        };
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1467,6 +1467,19 @@ exports.LoadUtils = () => {
         return true;
     };
 
+    window.WWebJS.getOngoingCall = () => {
+        // lastActiveCall keeps pointing at the previous call even after it ends,
+        // so a call in the ended state (0) is treated as no ongoing call.
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return call;
+    };
+
     window.WWebJS.startCall = async (
         chatId,
         isVideo = false,
@@ -1500,22 +1513,24 @@ exports.LoadUtils = () => {
             .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
 
         // The call is registered in the collection shortly after the offer is
-        // sent, so wait for it to become available before returning its data.
+        // sent, so wait for the newly placed call to become available before
+        // returning its data.
         const collection = window.require('WAWebCallCollection');
-        let call = collection.lastActiveCall;
+        let call = null;
         for (let i = 0; i < 30 && !call; i++) {
             await new Promise((resolve) => setTimeout(resolve, 100));
-            call = collection.lastActiveCall;
+            call = window.WWebJS.getOngoingCall();
         }
 
         // Optionally block until the callee answers (or the timeout elapses).
         if (call && waitForAnswer) {
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {
+                const current = window.WWebJS.getOngoingCall();
                 if (
                     collection.isInConnectedCall &&
-                    collection.lastActiveCall &&
-                    collection.lastActiveCall.id === call.id
+                    current &&
+                    current.id === call.id
                 ) {
                     break;
                 }
@@ -1544,11 +1559,8 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getActiveCall = () => {
-        const call = window.require('WAWebCallCollection').lastActiveCall;
-        if (
-            !call ||
-            (typeof call.getState === 'function' && call.getState() === 0)
-        ) {
+        const call = window.WWebJS.getOngoingCall();
+        if (!call) {
             return null;
         }
         return {

--- a/tests/call.js
+++ b/tests/call.js
@@ -1,0 +1,160 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const Call = require('../src/structures/Call');
+const Client = require('../src/Client');
+
+const expect = chai.expect;
+
+// These are unit tests: the injected browser functions run inside WhatsApp Web,
+// so the pupPage.evaluate calls are stubbed and only the API surface (the
+// arguments handed to the injected layer) is asserted. No live session needed.
+describe('Calls', function () {
+    describe('Call', function () {
+        const callData = {
+            id: 'call-id',
+            peerJid: 'peer@c.us',
+            offerTime: 1700000000,
+            isVideo: false,
+            isGroup: false,
+            outgoing: true,
+        };
+
+        let client;
+        let call;
+
+        beforeEach(function () {
+            client = { pupPage: { evaluate: sinon.stub().resolves(true) } };
+            call = new Call(client, callData);
+        });
+
+        it('exposes the call data', function () {
+            expect(call.id).to.equal('call-id');
+            expect(call.from).to.equal('peer@c.us');
+            expect(call.timestamp).to.equal(1700000000);
+            expect(call.isVideo).to.equal(false);
+            expect(call.isGroup).to.equal(false);
+            expect(call.fromMe).to.equal(true);
+        });
+
+        describe('accept', function () {
+            it('answers with audio and injection on by default', async function () {
+                await call.accept();
+                expect(client.pupPage.evaluate.calledOnce).to.equal(true);
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['call-id', false, true]);
+            });
+
+            it('answers with video when requested', async function () {
+                await call.accept({ video: true });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', true, true]);
+            });
+
+            it('can disable audio injection to use the real microphone', async function () {
+                await call.accept({ injectAudio: false });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', false, false]);
+            });
+        });
+
+        describe('reject', function () {
+            it('rejects using the peer jid and the call id', async function () {
+                await call.reject();
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['peer@c.us', 'call-id']);
+            });
+        });
+
+        describe('end', function () {
+            it('ends the call by id', async function () {
+                await call.end();
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+
+        describe('playAudio', function () {
+            it('accepts a base64 string', async function () {
+                await call.playAudio('BASE64DATA');
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['BASE64DATA']);
+            });
+
+            it('accepts a MessageMedia and forwards its data', async function () {
+                await call.playAudio({
+                    mimetype: 'audio/ogg',
+                    data: 'MEDIA64',
+                });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['MEDIA64']);
+            });
+        });
+
+        describe('isConnected', function () {
+            it('returns the resolved connection state', async function () {
+                client.pupPage.evaluate.resolves(true);
+                const result = await call.isConnected();
+                expect(result).to.equal(true);
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+    });
+
+    describe('Client.call', function () {
+        let client;
+
+        beforeEach(function () {
+            client = {
+                pupPage: {
+                    evaluate: sinon.stub().resolves({
+                        id: 'new-call',
+                        peerJid: 'peer@c.us',
+                        isVideo: false,
+                        isGroup: false,
+                        outgoing: true,
+                    }),
+                },
+            };
+        });
+
+        it('places a voice call with injection on by default', async function () {
+            const result = await Client.prototype.call.call(
+                client,
+                '15551234567',
+            );
+            expect(result).to.be.instanceOf(Call);
+            expect(result.id).to.equal('new-call');
+            const args = client.pupPage.evaluate.firstCall.args;
+            expect(args[0]).to.be.a('function');
+            expect(args.slice(1)).to.deep.equal([
+                '15551234567',
+                false,
+                false,
+                60000,
+                true,
+            ]);
+        });
+
+        it('forwards video, waitForAnswer, answerTimeout and injectAudio', async function () {
+            await Client.prototype.call.call(client, '15551234567', {
+                video: true,
+                waitForAnswer: true,
+                answerTimeout: 1000,
+                injectAudio: false,
+            });
+            expect(
+                client.pupPage.evaluate.firstCall.args.slice(1),
+            ).to.deep.equal(['15551234567', true, true, 1000, false]);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Adds first-class call support: answer incoming calls, place outgoing calls, and
inject audio (e.g. a text-to-speech file) into an active call. Also fixes call
handling that no longer works on current WhatsApp Web.

New `Call` methods:
- `accept()` — answer the call (audio only by default, even for incoming video calls)
- `end()` — hang up an ongoing call
- `playAudio(media)` — play a `MessageMedia`/base64 audio clip into the call so the
  other party hears it; resolves when playback finishes, so clips can be chained
- `isConnected()` — whether the other party has answered

New `Client` methods:
- `call(chatId, { video, waitForAnswer, answerTimeout })` — place an outgoing
  voice/video call; with `waitForAnswer: true` it resolves once the callee answers
- `getActiveCall()` — the ongoing call (ringing/placing/connected), or `null`

Fixes:
- Incoming `call` event: current WhatsApp Web surfaces calls through
  `WAWebCallCollection`'s `activeCall` attribute; the previous internal-map `set`
  hook no longer fires, so `client.on('call')` never triggered. Now listens to
  `change:activeCall` (the map hook is kept as a fallback).
- `Call.reject()`: the previous signaling stanza no longer rejects on current
  WhatsApp Web; it now goes through the voip stack's `rejectCall()`.

Audio is captured from a synthetic Web Audio stream (WhatsApp's `getUserMedia` is
overridden), so **no microphone is required and it works headless**. The browser
flags needed for this are added automatically.

## Related Issue(s)

fixes #201746

## Testing Summary

### Test Details

Verified end-to-end against a real phone with live calls.

Outgoing voice call + audio + hang up:

```js
const call = await client.call('1XXXXXXXXXX', { waitForAnswer: true });
if (await call.isConnected()) {
    await call.playAudio(MessageMedia.fromFilePath('./hello.wav'));
    await call.end();
}
```

Incoming call handling:

```js
client.on('call', async (call) => {
    if (call.fromMe) return;
    await call.accept();                 // or await call.reject()
    await call.playAudio(MessageMedia.fromFilePath('./welcome.wav'));
    await call.end();
});
```

Confirmed: incoming voice/video calls fire the `call` event; `accept`, `reject`,
`end`, sequential `playAudio` and `getActiveCall` all work; the callee hears the
injected audio; video calls are answered audio-only; everything also works with a
headless browser and no microphone.

Note: the repo's `npm test` integration suite requires a configured live test
account (`WWEBJS_TEST_REMOTE_ID` etc.) and only covers messaging/groups, not
calls, so verification was done manually with real calls as shown above.

### Environment

- Machine OS: Windows 11
- Phone OS: Android 16
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1017054665
- Browser Type and Version: Google Chrome 149
- Node Version: 22.17.0

## Type of Change

- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [x] **New feature** _(non-breaking change that adds functionality)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`) — the integration suite needs a live test account and only covers messaging/groups; verified manually with real calls.
- [x] Typings (`index.d.ts`) have been updated.
- [x] Usage examples (`example.js`) / documentation have been updated.
