### PR TITLE
feat: chat with Meta AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For more details on saving and restoring sessions, check out the [Authentication
 | Send location                                    | ✅                                           |
 | Send buttons                                     | ❌ [(DEPRECATED)][deprecated-video]          |
 | Send lists                                       | ❌ [(DEPRECATED)][deprecated-video]          |
+| Chat with Meta AI                                | ✅                                           |
 | Receive location                                 | ✅                                           |
 | Message replies                                  | ✅                                           |
 | Join groups by invite                            | ✅                                           |

--- a/example.js
+++ b/example.js
@@ -73,6 +73,16 @@ client.on('message', async (msg) => {
     } else if (msg.body === '!ping') {
         // Send a new message to the same chat
         client.sendMessage(msg.from, 'pong');
+    } else if (msg.body.startsWith('!ai ')) {
+        // Ask Meta AI and forward its reply back to the chat
+        const prompt = msg.body.slice(4);
+        const reply = await client.sendMetaAiMessage(prompt);
+        if (reply && reply.hasMedia) {
+            const media = await reply.downloadMedia();
+            client.sendMessage(msg.from, media, { caption: reply.body });
+        } else {
+            client.sendMessage(msg.from, reply ? reply.body : 'No response');
+        }
     } else if (msg.body.startsWith('!sendto ')) {
         // Direct send a new message to specific id
         let number = msg.body.split(' ')[1];

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,11 +211,14 @@ declare namespace WAWebJS {
             options?: MessageSendOptions,
         ): Promise<Message>;
 
+        /** Sends a message to Meta AI and resolves once its reply has finished streaming */
+        sendMetaAiMessage(
+            message: string,
+            options?: { timeout?: number },
+        ): Promise<Message | null>;
+
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(

--- a/src/Client.js
+++ b/src/Client.js
@@ -1619,6 +1619,25 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Sends a message to Meta AI and resolves once its reply has finished streaming
+     * @param {string} message The prompt to send to Meta AI
+     * @param {object} [options] Options
+     * @param {number} [options.timeout=60000] How long to wait for the reply, in milliseconds
+     * @returns {Promise<Message>} The reply from Meta AI, which may be a text or a media message
+     */
+    async sendMetaAiMessage(message, options = {}) {
+        const msg = await this.pupPage.evaluate(
+            (message, options) => {
+                return window.WWebJS.sendMetaAiMessage(message, options);
+            },
+            message,
+            options,
+        );
+
+        return msg ? new Message(this, msg) : null;
+    }
+
+    /**
      * Send an emoji reaction to a specific message
      * @param {string} messageId - Id of the message to add the reaction.
      * @param {string} reaction  - Emoji to react with. Send an empty string to remove the reaction.

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -585,6 +585,79 @@ exports.LoadUtils = () => {
             .Msg.get(newMsgKey._serialized);
     };
 
+    window.WWebJS.sendMetaAiMessage = async (message, options = {}) => {
+        const { Msg } = window.require('WAWebCollections');
+        const { BotMsgEditType } = window.require('WAWebBotTypes');
+        const chatId =
+            window.require('WAWebBotUtils').META_BOT_PN_WID._serialized;
+        const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
+
+        if (!chat) return null;
+
+        const previousIds = new Set(
+            Msg.getModelsArray()
+                .filter((msg) => msg.id?.remote?._serialized === chatId)
+                .map((msg) => msg.id?._serialized),
+        );
+
+        // Meta AI only replies when the outgoing message carries a bot secret.
+        const messageSecret = window.crypto.getRandomValues(new Uint8Array(32));
+        const botMessageSecret = await window
+            .require('WAWebBotMessageSecret')
+            .genBotMsgSecretFromMsgSecret(messageSecret);
+
+        await window.WWebJS.sendMessage(chat, message, {
+            messageSecret,
+            botMessageSecret,
+        });
+
+        const getReplies = () =>
+            Msg.getModelsArray().filter(
+                (msg) =>
+                    msg.id?.remote?._serialized === chatId &&
+                    msg.id?.fromMe === false &&
+                    !previousIds.has(msg.id?._serialized),
+            );
+        const isFinished = (msg) =>
+            msg.botEditType === BotMsgEditType.LAST ||
+            msg.botEditType === BotMsgEditType.FULL;
+
+        // The text reply streams in as a single message edited in place until
+        // the last chunk. A generated image arrives as a separate message right
+        // after, so wait for a finished reply plus a short quiet period to catch
+        // any trailing message.
+        const timeout = options.timeout ?? 60000;
+        const start = Date.now();
+        let signature = '';
+        let stableSince = start;
+
+        while (Date.now() - start < timeout) {
+            const replies = getReplies();
+            const currentSignature = replies
+                .map(
+                    (msg) =>
+                        `${msg.id?._serialized}:${msg.botEditType}:${Boolean(msg.directPath)}`,
+                )
+                .join('|');
+            if (currentSignature !== signature) {
+                signature = currentSignature;
+                stableSince = Date.now();
+            }
+            if (replies.some(isFinished) && Date.now() - stableSince >= 1500) {
+                break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+
+        const replies = getReplies();
+        const reply =
+            replies.find((msg) => msg.directPath) ||
+            replies.filter(isFinished).pop() ||
+            replies.pop();
+
+        return reply ? window.WWebJS.getMessageModel(reply) : null;
+    };
+
     window.WWebJS.editMessage = async (msg, content, options = {}) => {
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;


### PR DESCRIPTION
## What

Adds `client.sendMetaAiMessage(prompt, options?)` — send a prompt to Meta AI and receive its reply as a `Message` (text or media).

## Why

The library could already @-mention Meta AI in groups (`invokedBotWid`), but there was no way to hold a 1:1 conversation with Meta AI and get the answer back. This adds a first-class method for it.

## How

- Meta AI only replies when the outgoing message carries a bot secret, so the method generates `messageSecret` + `botMessageSecret` (via `WAWebBotMessageSecret.genBotMsgSecretFromMsgSecret`) and attaches them.
- The text reply streams in as a single message edited in place until its final chunk (`botEditType` reaches `last`, or `full` for a one-shot answer). A generated image arrives as a separate message right after, so the method waits for a finished reply plus a short quiet period and returns the media message when one is produced.
- Returns a `Message`, so both text and generated images flow through the existing Message API (`downloadMedia`, etc.). `options.timeout` (default `60000` ms) caps the wait.

## Usage

```js
const reply = await client.sendMetaAiMessage('What is WhatsApp? Answer in one sentence.');
console.log(reply.body);

// "generate an image ..." prompts come back as an image message
if (reply.hasMedia) {
    const media = await reply.downloadMedia();
}
```

## Notes

Meta AI availability is region-gated by WhatsApp; where available this works even when the web UI entry point is hidden.

## Tested

Verified against a live session:
- Text: "2+2?" → "Dört", capital-of-country prompts → "Ankara" / "Paris".
- Image: "generate an image of a car" → an `image` message; `downloadMedia()` returns the JPEG (~255 KB).
- Multi-sentence answers stream and resolve fully.
