### PR TITLE
feat: expose the current user LID on ClientInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -673,6 +673,8 @@ declare namespace WAWebJS {
         me: ContactId;
         /** Current user ID */
         wid: ContactId;
+        /** Current user LID, when the account has a LID-addressing identity */
+        lid?: ContactId;
         /**
          * Information about the phone this client is connected to.  Not available in multi-device.
          * @deprecated

--- a/src/Client.js
+++ b/src/Client.js
@@ -350,6 +350,9 @@ class Client extends EventEmitter {
                                         window
                                             .require('WAWebUserPrefsMeUser')
                                             .getMaybeMeLidUser(),
+                                    lid: window
+                                        .require('WAWebUserPrefsMeUser')
+                                        .getMaybeMeLidUser(),
                                 };
                             }),
                         );

--- a/src/structures/ClientInfo.js
+++ b/src/structures/ClientInfo.js
@@ -27,6 +27,12 @@ class ClientInfo extends Base {
         this.wid = data.wid;
 
         /**
+         * Current user LID, when the account has a LID-addressing identity
+         * @type {object|undefined}
+         */
+        this.lid = data.lid;
+
+        /**
          * @type {object}
          * @deprecated Use .wid instead
          */

--- a/tests/client.js
+++ b/tests/client.js
@@ -182,6 +182,19 @@ describe('Client', function () {
             console.log(`WA Version: ${version}`);
         });
 
+        describe('Client Info', function () {
+            it('exposes the current user LID when the account has one', function () {
+                const { lid } = client.info;
+                if (lid) {
+                    expect(lid).to.have.property('_serialized');
+                    expect(lid._serialized).to.match(/@lid$/);
+                } else {
+                    // Not every account has a LID-addressing identity.
+                    expect(lid).to.be.undefined;
+                }
+            });
+        });
+
         describe('Send Messages', function () {
             it('can send a message', async function () {
                 const msg = await client.sendMessage(remoteId, 'hello world');


### PR DESCRIPTION
## Description

Adds a `lid` property to `ClientInfo`, exposing the current user's own LID (WhatsApp's phone-number-decoupled "Linked ID"), alongside the existing `wid`.

WhatsApp is migrating addressing from phone-number JIDs to LIDs, so a client increasingly needs its own LID. For example, to detect self-mentions in a group a bot compares `message.mentionedIds` against its own identity, and depending on the group's phone-number-privacy setting those ids can be LIDs. `ClientInfo` currently exposes only `wid` (the phone-number id), and there is no supported way to read the LID, so consumers reach into internal Store modules instead.

`lid` is populated from `WAWebUserPrefsMeUser.getMaybeMeLidUser()`, the same accessor the library already uses internally, and mirrors how `wid` is set. It is optional because not every account has a resolvable LID (`getMaybeMeLidUser` may return nothing).

## Related Issue(s)

None. Additive, standalone enhancement.

## Testing Summary

### Test Details

Verified end to end on a live WhatsApp Web session by consuming this build from a production bot: `client.info.lid` returns the account's `@lid` (e.g. `203539171270783@lid`), and the bot resolves its own LID from it on startup. Added a unit test (`tests/client.js`) asserting `client.info.lid` is a valid `@lid` id when present, and `undefined` otherwise. `eslint .` and `prettier --check` pass. The full mocha integration suite (`npm test`) requires a linked test account and was not run here.

### Environment

- Machine OS: macOS 15.7.7 (Sequoia)
- Phone OS: Android 14 (Google Play x86_64 emulator)
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1043185461
- Browser Type and Version: Chromium (puppeteer default)
- Node Version: 24.14.1

## Type of Change

- [ ] **Dependency change**
- [ ] **Bug fix**
- [x] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change**
- [ ] **Non-code change**

## Checklist

- [x] My code follows the style guidelines of this project. _(`eslint .` and `prettier --check` pass.)_
- [ ] All new and existing tests pass (`npm test`). _(Added a test and verified end to end on a live build via a downstream consumer; the full integration suite needs a linked test account, so it is left for CI/maintainers.)_
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples / documentation have been updated if applicable. _(JSDoc on `ClientInfo.lid` and the `index.d.ts` type.)_