### PR TITLE
fix(reaction): populate _serialized on reaction msg keys

### DIFF
--- a/src/structures/Reaction.js
+++ b/src/structures/Reaction.js
@@ -18,7 +18,7 @@ class Reaction extends Base {
          * Reaction ID
          * @type {object}
          */
-        this.id = data.msgKey;
+        this.id = Reaction._withSerializedId(data.msgKey);
         /**
          * Orphan
          * @type {number}
@@ -48,7 +48,7 @@ class Reaction extends Base {
          * Message ID
          * @type {object}
          */
-        this.msgId = data.parentMsgKey;
+        this.msgId = Reaction._withSerializedId(data.parentMsgKey);
         /**
          * Sender ID
          * @type {string}
@@ -61,6 +61,22 @@ class Reaction extends Base {
         this.ack = data.ack;
 
         return super._patch(data);
+    }
+
+    /**
+     * Returns a MsgKey with `_serialized` populated. WhatsApp Web's July 2026 build renamed the
+     * property to the minifier-mangled `$1`; `id` and `msgId` are typed as `MessageId`, whose
+     * `_serialized` is not optional, so consumers read it directly. Leaves an already-serialized
+     * key untouched.
+     * @param {object} key
+     * @returns {object}
+     * @private
+     */
+    static _withSerializedId(key) {
+        if (key && key._serialized == null && key.$1 != null) {
+            return Object.assign({}, key, { _serialized: key.$1 });
+        }
+        return key;
     }
 }
 


### PR DESCRIPTION
Closes #201846.

### What

`Reaction` assigns both of its keys straight through from `data`:

```js
this.id = data.msgKey;          // Reaction.js:21
this.msgId = data.parentMsgKey; // Reaction.js:51
```

On the July 2026 WhatsApp Web build those keys carry `$1` instead of `_serialized`, so `reaction.id._serialized` and `reaction.msgId._serialized` are `undefined` — while `index.d.ts` types both as `MessageId`, whose `_serialized` is not optional. Consumers read it directly and get nothing back, silently.

It's the only `Base` subclass whose ids aren't named `data.id`, which is why the sweep in #201832 doesn't reach it. That PR does fix `senderUserJid` in the same reaction handler, but these two keys are passed through as objects rather than read, so there was no `_serialized` access there to catch.

### How

Normalizes both keys, leaving an already-serialized key untouched. Independent of #201832 — it doesn't use `Base._normalizeId`, so it applies to `main` as-is and the two can land in either order. If #201832 lands first and you'd rather this delegate to `Base._normalizeId`, happy to rebase it that way.

### Verified

| build | result |
|---|---|
| `$1` only | `msgId._serialized` → `'true_1@c.us_M1'`; `remote` / `fromMe` / `id` preserved |
| `_serialized` present | identity — same object reference, no copy |
| key `undefined` | no throw |

### Notes

Found while tracking the rename downstream in a project that uses this library. The `message_reaction` path was the one that stayed broken after applying the #201832 changes, which is what led here. Also visible from the outside in the workaround script in #201829, which patches `reaction.msgId._serialized` on the consumer side.
