### PR TITLE
fix: tolerate WhatsApp Web renaming the message key _serialized to $1

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -836,6 +836,20 @@ exports.LoadUtils = () => {
             });
         }
 
+        // The rename reaches the serialized model too: `msg.id` comes back carrying `$1` and no
+        // `_serialized`, so every consumer of `message.id._serialized` — including this library's own
+        // Message structure and anything keyed on a message id — silently receives undefined. Restore
+        // it here, where `msg.id.remote` is already normalised, so the whole downstream surface keeps
+        // working rather than each caller having to know about `$1`.
+        if (typeof msg.id === 'object' && msg.id._serialized == null) {
+            const serializedId = window.WWebJS.getMsgKeyId(msg.id);
+            if (serializedId) {
+                msg.id = Object.assign({}, msg.id, {
+                    _serialized: serializedId,
+                });
+            }
+        }
+
         delete msg.pendingAckUpdate;
 
         return msg;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -582,7 +582,7 @@ exports.LoadUtils = () => {
 
         return window
             .require('WAWebCollections')
-            .Msg.get(newMsgKey._serialized);
+            .Msg.get(window.WWebJS.getMsgKeyId(newMsgKey));
     };
 
     window.WWebJS.editMessage = async (msg, content, options = {}) => {
@@ -625,7 +625,9 @@ exports.LoadUtils = () => {
         await window
             .require('WAWebSendMessageEditAction')
             .sendMessageEdit(msg, content, internalOptions);
-        return window.require('WAWebCollections').Msg.get(msg.id._serialized);
+        return window
+            .require('WAWebCollections')
+            .Msg.get(window.WWebJS.getMsgKeyId(msg.id));
     };
 
     window.WWebJS.toStickerData = async (mediaInfo) => {
@@ -917,6 +919,20 @@ exports.LoadUtils = () => {
         };
     };
 
+    /**
+     * The serialized id of a message key, tolerating WhatsApp Web having renamed the key's
+     * `_serialized` property to `$1`. Reading the old name now returns `undefined`, which reaches
+     * IndexedDB as a `.get(undefined)` and throws
+     * `DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.`
+     * `_serialized` is preferred so nothing changes wherever it is still present (chat ids, for
+     * example, are unaffected by the rename). Returns undefined when neither exists, so callers can
+     * skip the lookup instead of querying a store with a nullish key.
+     * @param {Object} key a message key, e.g. `chat.lastReceivedKey` or a raw `msg.id`
+     * @returns {string|undefined}
+     */
+    window.WWebJS.getMsgKeyId = (key) =>
+        key?._serialized ?? key?.$1 ?? undefined;
+
     window.WWebJS.getChats = async () => {
         const chats = window.require('WAWebCollections').Chat.getModelsArray();
         const chatPromises = chats.map((chat) =>
@@ -981,16 +997,17 @@ exports.LoadUtils = () => {
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            const lastMessage = chat.lastReceivedKey
+            const lastReceivedKeyId = window.WWebJS.getMsgKeyId(
+                chat.lastReceivedKey,
+            );
+            const lastMessage = lastReceivedKeyId
                 ? window
                       .require('WAWebCollections')
-                      .Msg.get(chat.lastReceivedKey._serialized) ||
+                      .Msg.get(lastReceivedKeyId) ||
                   (
                       await window
                           .require('WAWebCollections')
-                          .Msg.getMessagesById([
-                              chat.lastReceivedKey._serialized,
-                          ])
+                          .Msg.getMessagesById([lastReceivedKeyId])
                   )?.messages?.[0]
                 : null;
             lastMessage &&


### PR DESCRIPTION
## The bug

WhatsApp Web renamed the **message key's** `_serialized` property to `$1`.

`getChatModel` reads `chat.lastReceivedKey._serialized` ([Utils.js#L984-L997](https://github.com/wwebjs/whatsapp-web.js/blob/main/src/util/Injected/Utils.js#L984-L997)), which now yields `undefined` and reaches IndexedDB as `Msg.getMessagesById([undefined])`:

```
DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.
```

`getChats()` maps `getChatModel` over every chat under `Promise.all`, so **one** affected chat rejects the entire batch — surfacing to callers as an opaque minified error (widely reported as **`r: r`**) while the client is `CONNECTED` and WhatsApp Web is fully loaded.

**Chat ids are not affected** — they still carry `_serialized`. That is why this doesn't look like the `$1` rename, and why fixes that normalize ids in the Node-side `structures/` layer don't reach it: the throw happens *in-page*, inside `getChatModel`, before anything is returned.

## Evidence

Measured on two live sessions (WA Web `2.3000.1043280533`, whatsapp-web.js `1.34.7`) by catching the error **inside** `page.evaluate` so the in-page stack survives the CDP boundary (otherwise it collapses to `name: message`, i.e. `r: r`):

| | chats | with `lastReceivedKey` | of those, having `_serialized` | `getChatModel` result |
|---|---|---|---|---|
| session A | 1253 | 916 | **0** | 916 threw · 337 ok |
| session B | 515 | 498 | **0** | — |

Chats with no last message skip the block entirely — which is exactly the observed 337 / 916 split. Sampled keys look like:

```
keys: [fromMe, remote, id, $1]      _serialized: undefined      $1: "true_1252928…@lid_3A7…"
```

Re-running the same lookup with `_serialized ?? $1` returned the message on **every** affected chat.

## The fix

Adds `window.WWebJS.getMsgKeyId(key)`:

- prefers `_serialized`, so behaviour is **unchanged** wherever it is still present;
- returns `undefined` when neither exists, so callers skip the lookup rather than querying a store with a nullish key.

Applied to the three places a **raw** (un-`serialize()`d) message key is read: `getChatModel`, `sendMessage`, `editMessage`.

`getMessageModel` is deliberately untouched — it reads a `serialize()`d model, which still produces `_serialized`. `msg.id.remote._serialized` is also untouched: `remote` is a *chat* id, which the rename didn't affect.

Only `getChatModel` is verified against live sessions; `sendMessage`/`editMessage` read a raw key of the same shape and get the same one-token change. The helper is a no-op where `_serialized` still exists, so it cannot regress either path.

Refs #201845, #201844, #201846

---
Prettier + the existing style are unchanged (`prettier --check` passes; diff is 1 file, +24/−7).