### PR TITLE
fix(getChatModel): guard lastMessage read against empty IDB key

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -981,18 +981,28 @@ exports.LoadUtils = () => {
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            const lastMessage = chat.lastReceivedKey
-                ? window
-                      .require('WAWebCollections')
-                      .Msg.get(chat.lastReceivedKey._serialized) ||
-                  (
-                      await window
-                          .require('WAWebCollections')
-                          .Msg.getMessagesById([
-                              chat.lastReceivedKey._serialized,
-                          ])
-                  )?.messages?.[0]
-                : null;
+            let lastMessage = null;
+            try {
+                // Guard against an empty/undefined lastReceivedKey._serialized,
+                // which causes WAWebCollections.Msg.get() to invoke
+                // IDBObjectStore.get() with no key and throw a DataError
+                // ("Failed to execute 'get' on 'IDBObjectStore': No key or
+                // key range specified"). This breaks every getChats() /
+                // getMessages() call for affected chats. Fall back to null.
+                const lastKey =
+                    chat.lastReceivedKey && chat.lastReceivedKey._serialized;
+                if (lastKey) {
+                    lastMessage =
+                        window.require('WAWebCollections').Msg.get(lastKey) ||
+                        (
+                            await window
+                                .require('WAWebCollections')
+                                .Msg.getMessagesById([lastKey])
+                        )?.messages?.[0];
+                }
+            } catch (ignoredError) {
+                lastMessage = null;
+            }
             lastMessage &&
                 (model.lastMessage =
                     window.WWebJS.getMessageModel(lastMessage));


### PR DESCRIPTION
## Problem

`Client.getChats()` and `Client.getChatById()` throw a minified `Evaluation failed: r: r` error from puppeteer, causing every chat-listing / message-fetching call to fail with HTTP 500 (or the equivalent in host applications). The error is silent in the host because the in-page error message is minified to a single character.

## Root cause

`window.WWebJS.getChatModel` builds `model.lastMessage` by reading:

```js
const lastMessage = chat.lastReceivedKey
    ? window.require('WAWebCollections').Msg.get(chat.lastReceivedKey._serialized) || ...
    : null;
```

When `chat.lastReceivedKey._serialized` is empty or `undefined`, `Msg.get()` invokes `IDBObjectStore.get()` with no key, which throws:

```
DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.
```

This propagates out of `getChatModel` → `getChat` → `getChatById` / `getChats`. `getContacts()` is unaffected because it does not touch the message IDB store, which is why contacts continue to work while chats/messages do not.

## Reproduction

Reproduced across multiple WhatsApp Web bundle versions (`2.3000.1042903797` and `2.3000.1043346688`), so it is **not** version-specific — it depends on the chat's `lastReceivedKey` state, not the bundle. Diagnosis was done by stepping through `WWebJS.getChat` in-page and confirming the throw occurs at `getChatModel` (after `findOrCreateLatestChat` succeeds and `hasChat` is true):

```
getChatModel => THROW:Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.
```

## Fix

Only attempt the `Msg.get()` / `getMessagesById()` reads when `lastReceivedKey._serialized` is a non-empty string, and wrap the reads in `try/catch` so any remaining `DataError` falls back to `lastMessage: null` instead of throwing out of `getChatModel`. The chat model is still returned; only the `lastMessage` field is `null` when it cannot be resolved.

## Backward compatibility

Behaviour is unchanged for chats with a valid `lastReceivedKey._serialized`. For chats that previously threw (breaking the entire `getChats`/`getMessages` call), they now return successfully with `lastMessage: null`.

## Validation

- `npx eslint src/util/Injected/Utils.js` — clean (caught error named `ignoredError` per the existing `no-unused-vars` convention in this file).
- `node -c src/util/Injected/Utils.js` — syntax OK.
- Verified end-to-end against a live WhatsApp session: `getChats` and `getMessages` return 200 with real data after the fix, where they previously returned 500.

The existing mocha test suite requires a live WhatsApp session and does not unit-test the injected `Utils.js` code, so no test changes are included.

## Files changed

- `src/util/Injected/Utils.js`: guarded the `lastMessage` read in `getChatModel`.

No confidential data (keys, session data, phone numbers) is included in this PR.