### PR TITLE
fix: drive connection lifecycle from WhatsApp's Stream model

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -286,6 +286,26 @@ class Client extends EventEmitter {
                 },
             );
 
+            /**
+             * Maps WhatsApp's resolved connection screen onto the public client
+             * events. QR and ERROR are intentionally absent: they keep their own
+             * code paths and emit nothing here.
+             * @event Client#ready
+             * @event Client#loading_screen
+             */
+            const EMIT_BY_SCREEN = {
+                CONNECTED: () => [Events.READY],
+                LOADING: (percent) => [
+                    Events.LOADING_SCREEN,
+                    percent,
+                    'WhatsApp',
+                ],
+                DISCONNECTED: (percent) => [
+                    Events.LOADING_SCREEN,
+                    percent,
+                    'WhatsApp',
+                ],
+            };
             await exposeFunctionIfAbsent(
                 this.pupPage,
                 'onAppStateHasSyncedEvent',
@@ -357,24 +377,60 @@ class Client extends EventEmitter {
                         this.interface = new InterfaceController(this);
 
                         await this.attachEventListeners();
+
+                        // Connection lifecycle: subscribe to WhatsApp's own
+                        // Stream model (the same signals its loading screen
+                        // renders from) now that ClientInfo exists, then fire
+                        // once for the current state. Backbone only fires on
+                        // real changes, so there is no init race, no backstop
+                        // and no manual de-dup.
+                        await this.pupPage.evaluate(() => {
+                            const {
+                                Stream,
+                                StreamMode: M,
+                                StreamInfo: I,
+                            } = window.require('WAWebStreamModel');
+                            const resolveScreen = () => {
+                                switch (Stream.mode) {
+                                    case M.MAIN:
+                                        return Stream.displayInfo === I.NORMAL
+                                            ? 'CONNECTED'
+                                            : 'LOADING';
+                                    case M.QR:
+                                        return 'QR';
+                                    case M.OFFLINE:
+                                        return 'DISCONNECTED';
+                                    case M.SYNCING:
+                                        return 'LOADING';
+                                    default:
+                                        return 'ERROR';
+                                }
+                            };
+                            let lastScreen = null;
+                            const notify = () => {
+                                const screen = resolveScreen();
+                                if (screen === lastScreen) return;
+                                lastScreen = screen;
+                                window.onConnectionStateEvent(
+                                    screen,
+                                    window
+                                        .require('WAWebOfflineHandler')
+                                        .OfflineMessageHandler.getOfflineDeliveryProgress(),
+                                );
+                            };
+                            Stream.on('change:mode change:displayInfo', notify);
+                            notify();
+                        });
                     }
-                    /**
-                     * Emitted when the client has initialized and is ready to receive messages.
-                     * @event Client#ready
-                     */
-                    this.emit(Events.READY);
                     this.authStrategy.afterAuthReady();
                 },
             );
-            let lastPercent = null;
             await exposeFunctionIfAbsent(
                 this.pupPage,
-                'onOfflineProgressUpdateEvent',
-                async (percent) => {
-                    if (lastPercent !== percent) {
-                        lastPercent = percent;
-                        this.emit(Events.LOADING_SCREEN, percent, 'WhatsApp'); // Message is hardcoded as "WhatsApp" for now
-                    }
+                'onConnectionStateEvent',
+                (screen, percent) => {
+                    const args = EMIT_BY_SCREEN[screen]?.(percent);
+                    if (args) this.emit(...args);
                 },
             );
             await exposeFunctionIfAbsent(
@@ -404,17 +460,6 @@ class Client extends EventEmitter {
                         'change:hasSynced',
                         () => {
                             window.onAppStateHasSyncedEvent();
-                        },
-                    ],
-                    [
-                        Cmd,
-                        'offline_progress_update_from_bridge',
-                        () => {
-                            window.onOfflineProgressUpdateEvent(
-                                window
-                                    .require('WAWebOfflineHandler')
-                                    .OfflineMessageHandler.getOfflineDeliveryProgress(),
-                            );
                         },
                     ],
                     [

--- a/src/Client.js
+++ b/src/Client.js
@@ -258,6 +258,16 @@ class Client extends EventEmitter {
                             .require('WAWebConnModel')
                             .Conn.on('change:ref', onRefChange); // future QR changes
 
+                        // The synced handler subscribes too late for a scan.
+                        const { Stream, StreamMode } =
+                            window.require('WAWebStreamModel');
+                        const onScanned = () => {
+                            if (Stream.mode !== StreamMode.SYNCING) return;
+                            Stream.off('change:mode', onScanned);
+                            window.onConnectionStateEvent?.('LOADING', 0);
+                        };
+                        Stream.on('change:mode', onScanned);
+
                         // Remove QR listener once authentication succeeds
                         window
                             .require('WAWebSocketModel')

--- a/src/Client.js
+++ b/src/Client.js
@@ -392,18 +392,27 @@ class Client extends EventEmitter {
                         // Stream model (the same signals its loading screen
                         // renders from) now that ClientInfo exists, then fire
                         // once for the current state. Backbone only fires on
-                        // real changes, so there is no init race, no backstop
-                        // and no manual de-dup.
+                        // real changes, so there is no init race and no manual
+                        // de-dup.
                         await this.pupPage.evaluate(() => {
                             const {
                                 Stream,
                                 StreamMode: M,
                                 StreamInfo: I,
                             } = window.require('WAWebStreamModel');
+                            // WA >= 2.3000.1046055909 moved displayInfo out of
+                            // the model into WAWebStreamGetters. Whichever a
+                            // build has answers; deriving it does not work, no
+                            // combination of the inputs is equivalent.
+                            const displayInfo = () =>
+                                window
+                                    .require('WAWebStreamGetters')
+                                    ?.getDisplayInfo?.(Stream) ??
+                                Stream.displayInfo;
                             const resolveScreen = () => {
                                 switch (Stream.mode) {
                                     case M.MAIN:
-                                        return Stream.displayInfo === I.NORMAL
+                                        return displayInfo() === I.NORMAL
                                             ? 'CONNECTED'
                                             : 'LOADING';
                                     case M.QR:
@@ -428,7 +437,10 @@ class Client extends EventEmitter {
                                         .OfflineMessageHandler.getOfflineDeliveryProgress(),
                                 );
                             };
-                            Stream.on('change:mode change:displayInfo', notify);
+                            // The generic event: change:displayInfo cannot fire
+                            // where the attribute is gone, and naming the inputs
+                            // would break the next time WA moves them.
+                            Stream.on('change', notify);
                             notify();
                         });
                     }


### PR DESCRIPTION
## Description

After a client is ready, an account can get stuck on a permanent loading state even though WhatsApp is connected and messages keep arriving. It comes from how the connection state is derived: from the one-shot `ready` event plus the raw offline-delivery percentage (`getOfflineDeliveryProgress()`). A background (non-blocking) offline sync fires `offline_progress_update` events that are surfaced as `loading_screen`, which flips a connected client back to loading. That percentage caps at 99 for a non-blocking resume, and `ready` only fires once, so it never comes back.

WhatsApp Web itself doesn't track the connection like that. Its own loading screen renders from WhatsApp's `Stream` model, reading `Stream.mode` and `Stream.displayInfo`. This does the same thing: it subscribes to `Stream`'s `change:mode` / `change:displayInfo` and maps that state onto the existing `ready` / `loading_screen` events. It emits `ready` when `mode` is `MAIN` and `displayInfo === NORMAL`, `loading_screen` while it's syncing or offline, and nothing for the QR and error screens (those keep their own paths). The model only fires a change event on an actual change, so there's nothing to de-duplicate by hand.

The listener is registered after `ClientInfo` is built and fires once for the current state. Because it registers after init and only reacts to real `Stream` changes, there's no first-connect race, no separate "first ready" path, and nothing to de-dup manually. As a side effect this also generalizes #201653: `ready` now comes only from real `Stream` transitions (deduped by last screen), so a re-injection can't double-emit it.

**Changes:**

- Subscribe to `Stream` `change:mode change:displayInfo` and map it onto the existing events: emit `ready` when connected, `loading_screen` while syncing or offline, and nothing for QR or error screens (they keep their own paths)
- Register it after `ClientInfo` exists and fire once, so a consumer gets the current state without waiting for the next change
- Drop the one-shot `ready` emit from the app-state-synced handler (the init flow stays, it just no longer decides "connected")
- Remove the old `offline_progress_update` to `loading_screen` path

No new events and no signature changes, so existing consumers keep working unchanged.

## Related

This is a long-standing, frequently reported symptom: WhatsApp Web is connected and its UI is fully loaded, but the client never surfaces `ready`, or `ready` only arrives later when a message happens to come in, typically after a restart or with a restored session. Deriving the state from WhatsApp's own `Stream` model and firing once for the current state is what closes that gap: it no longer depends on catching a single one-time transition. Reports of this exact symptom:

- #201821 - "Ready event only fires when there are new messages" (the reporter traced it to the `attachEventListeners` / ready path).
- #127084 - `ready` never fires after auth on v1.34.6 / WA 2.3000.x; commenters note `loading_screen` reaches 100% then goes silent after a restart and only fires once a message arrives.
- #2454 - stuck at "LOADING SCREEN 100" with WhatsApp Web fully loaded, `ready` never fires (still reproduced on recent versions).
- #5773 - authenticated and shown online, but `ready` never fires and the client never responds.
- #5801 - authenticated but never `ready`.

Prior work this builds on:

- #201653 - generalizes the recent duplicate-`ready`-on-re-injection fix (now inherent, since `ready` only follows real `Stream` transitions).
- #201734 (partial) - a stream going `DISCONNECTED` now emits a `loading_screen` event instead of the state changing silently. This does not address that report's underlying ghost socket (`wsReadyState: null`); it only makes the state transition observable.

For accuracy, these share the same "`ready` never fires" symptom but have a different, already-identified root cause and are **not** addressed here: #3971 / #3798 (an A/B test leaves `WAWebSetPushnameConnAction` unloaded, so the `Store.js` injection throws), #3958 (local cache corruption), #5717 (missing IndexedDB session blobs).

## Testing Summary

### Test Details

Ran it against a persisted session over several hours, watching the emitted events and the resulting connection state. Boot connects and emits a single `ready`; the background offline sync that used to pin it to loading no longer touches the state (zero `loading_screen` reverts after `ready` across the whole run), while incoming messages keep processing. Verified across repeated full re-launches that it reaches connected via exactly one `ready`, with no duplicate and no listeners left behind.

### Environment

- Machine OS: Windows 11
- Phone OS: Android 14
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.1043363706
- Browser Type and Version: Chromium 138
- Node Version: 22.20.0

## Type of Change

- [ ] Dependency change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Non-code change

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
