### PR TITLE
fix: guard undefined lastReceivedKey._serialized in getChatModel

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -981,16 +981,21 @@ exports.LoadUtils = () => {
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            const lastMessage = chat.lastReceivedKey
+            // `lastReceivedKey` can be present while its `_serialized` is
+            // undefined. Passing that undefined on to `getMessagesById` makes
+            // IndexedDB throw `DataError: Failed to execute 'get' on
+            // 'IDBObjectStore': No key or key range specified.`, which surfaces
+            // to callers as an unreadable minified error, so check the id
+            // itself rather than the key object.
+            const lastReceivedKeyId = chat.lastReceivedKey?._serialized;
+            const lastMessage = lastReceivedKeyId
                 ? window
                       .require('WAWebCollections')
-                      .Msg.get(chat.lastReceivedKey._serialized) ||
+                      .Msg.get(lastReceivedKeyId) ||
                   (
                       await window
                           .require('WAWebCollections')
-                          .Msg.getMessagesById([
-                              chat.lastReceivedKey._serialized,
-                          ])
+                          .Msg.getMessagesById([lastReceivedKeyId])
                   )?.messages?.[0]
                 : null;
             lastMessage &&


### PR DESCRIPTION
### Problem

On current WhatsApp Web builds (reproduced on `2.3000.1044135300`), any call that goes through `getChatModel()` — `client.getChatById()`, `message.getChat()`, `client.getChats()` — fails with an unreadable minified error:

```
Error processing message: r: r
    at #evaluate (.../puppeteer-core/lib/cjs/puppeteer/cdp/ExecutionContext.js:391:56)
    ...
    at async Client.getChatById (.../whatsapp-web.js/src/Client.js:1694:22)
```

### Root cause

`chat.lastReceivedKey` can be a **present object whose `_serialized` is `undefined`**. The check on line 984 tests the key object for truthiness, so it passes, and the undefined id is then handed to `Msg.getMessagesById([undefined])`. IndexedDB rejects it:

```
DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.
```

Because the throw originates inside the page, callers only ever see the minified `r: r`.

### Evidence

Probing a live authenticated session against a group chat, walking the `getChat` path step by step:

| step | result |
| --- | --- |
| `createWid` | ok |
| `Chat.get(wid)` | ok — chat found |
| `findOrCreateLatestChat` | ok |
| `groupMetadata.update(chatWid)` | ok |
| `chat.serialize()` | ok |
| `chat.lastReceivedKey` | **present** |
| `chat.lastReceivedKey._serialized` | **`undefined`** |
| `Msg.getMessagesById([undefined])` | **THREW `DataError: … No key or key range specified.`** |
| `WWebJS.getChatModel(chat)` | **THREW same `DataError`** |

This is not module drift — every module id the injected store relies on (`WAWebCollections`, `WAWebWidFactory`, `WAWebFindChatAction`, `WAWebDownloadManager`) resolves fine on that build, and `WAWebCollections` still exposes `Chat` and `Msg`.

### Fix

Read `chat.lastReceivedKey?._serialized` once and branch on the id rather than on the key object. When the id is missing, `lastMessage` falls through to `null` — exactly what the existing `: null` branch already yields for chats with no `lastReceivedKey`, so there is no behaviour change for chats that were already working.

### Notes

- Scope is deliberately narrow: this is the one internally-derived `_serialized` that is passed on unchecked. The other `getMessagesById` call sites take an id from a public API argument, so validating those is a separate discussion.
- The same undefined-`_serialized` shape also breaks `message.downloadMedia()` (`src/structures/Message.js:518`, via `this.id._serialized`) with the identical `DataError`. I left that out of this PR since the fix there is less obvious — the id has to be reconstructed from its parts rather than just guarded — but I'm happy to follow up if the approach here looks right.
- `npx eslint src/util/Injected/Utils.js` passes clean.
