### PR TITLE
feat(call): add experimental WhatsApp Web call controls

### DIFF
--- a/example.js
+++ b/example.js
@@ -697,7 +697,24 @@ client.on('call', async (call) => {
         call.from,
         `[${call.fromMe ? 'Outgoing' : 'Incoming'}] Phone call from ${call.from}, type ${call.isGroup ? 'group' : ''} ${call.isVideo ? 'video' : 'audio'} call. ${rejectCalls ? 'This call was automatically rejected by the script.' : ''}`,
     );
+
+    // Instead of rejecting, a call can also be answered and an audio clip
+    // (e.g. a text-to-speech file you generated) can be played into it:
+    // await call.accept(); // answers with audio only, even for video calls
+    // await call.playAudio(MessageMedia.fromFilePath('./welcome.mp3'));
+    // await call.end();
 });
+
+// Placing an outgoing call and speaking once the other party answers:
+// const call = await client.call('1234567890', { waitForAnswer: true });
+// if (await call.isConnected()) {
+//     await call.playAudio(MessageMedia.fromFilePath('./message.mp3'));
+//     await call.end();
+// }
+
+// Checking for an ongoing call and hanging it up:
+// const activeCall = await client.getActiveCall();
+// if (activeCall) await activeCall.end();
 
 client.on('disconnected', (reason) => {
     console.log('Client was logged out', reason);

--- a/index.d.ts
+++ b/index.d.ts
@@ -369,6 +369,13 @@ declare namespace WAWebJS {
         ): Promise<Call>;
 
         /**
+         * Gets the number of participants in the currently active WhatsApp
+         * call, or null when no call or countable roster is available.
+         * @experimental Depends on private WhatsApp Web internals.
+         */
+        getActiveCallParticipantCount(): Promise<number | null>;
+
+        /**
          * Adds an individual WhatsApp contact to the currently active call.
          * @experimental Depends on private WhatsApp Web internals and may reject
          * when no supported internal call controller is detected.

--- a/index.d.ts
+++ b/index.d.ts
@@ -357,11 +357,33 @@ declare namespace WAWebJS {
         getActiveCall(): Promise<Call | null>;
 
         /**
+         * Starts an outgoing WhatsApp group call.
+         * @experimental Depends on private WhatsApp Web internals and may reject
+         * when no supported internal group call controller is detected.
+         */
+        startGroupCall(
+            contactIds: string[],
+            options?: {
+                video?: boolean;
+            },
+        ): Promise<Call>;
+
+        /**
          * Adds an individual WhatsApp contact to the currently active call.
          * @experimental Depends on private WhatsApp Web internals and may reject
          * when no supported internal call controller is detected.
          */
         addParticipantToCall(contactId: string, callId?: string): Promise<void>;
+
+        /**
+         * Removes an individual WhatsApp contact from the currently active call.
+         * @experimental Depends on private WhatsApp Web internals and may reject
+         * when no supported internal call controller is detected.
+         */
+        removeParticipantFromCall(
+            contactId: string,
+            callId?: string,
+        ): Promise<void>;
 
         /**
          * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
@@ -2480,6 +2502,9 @@ declare namespace WAWebJS {
 
         /** Add an individual WhatsApp contact to the active call */
         addParticipant: (contactId: string) => Promise<void>;
+
+        /** Remove an individual WhatsApp contact from the active call */
+        removeParticipant: (contactId: string) => Promise<void>;
     }
 
     /** Message type List */

--- a/index.d.ts
+++ b/index.d.ts
@@ -357,6 +357,13 @@ declare namespace WAWebJS {
         getActiveCall(): Promise<Call | null>;
 
         /**
+         * Adds an individual WhatsApp contact to the currently active call.
+         * @experimental Depends on private WhatsApp Web internals and may reject
+         * when no supported internal call controller is detected.
+         */
+        addParticipantToCall(contactId: string, callId?: string): Promise<void>;
+
+        /**
          * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
          * @param response The response code to the event message. Valid values are: `0` for NONE response (removes a previous response) | `1` for GOING | `2` for NOT GOING | `3` for MAYBE going
          * @param eventMessageId The event message ID
@@ -2470,6 +2477,9 @@ declare namespace WAWebJS {
 
         /** Indicates whether the call is currently connected (the other party has answered) */
         isConnected: () => Promise<boolean>;
+
+        /** Add an individual WhatsApp contact to the active call */
+        addParticipant: (contactId: string) => Promise<void>;
     }
 
     /** Message type List */

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,10 +212,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
@@ -344,6 +341,19 @@ declare namespace WAWebJS {
 
         /** Generates a WhatsApp call link (video call or voice call) */
         createCallLink(startTime: Date, callType: string): Promise<string>;
+
+        /** Places an outgoing call to the provided chat or phone number */
+        call(
+            chatId: string,
+            options?: {
+                video?: boolean;
+                waitForAnswer?: boolean;
+                answerTimeout?: number;
+            },
+        ): Promise<Call>;
+
+        /** Gets the call that is currently ongoing (ringing, being placed or connected), if any */
+        getActiveCall(): Promise<Call | null>;
 
         /**
          * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
@@ -2444,6 +2454,18 @@ declare namespace WAWebJS {
 
         /** Reject the call */
         reject: () => Promise<void>;
+
+        /** Accept the call (audio only by default, even for incoming video calls) */
+        accept: (options?: { video?: boolean }) => Promise<boolean>;
+
+        /** End an ongoing call */
+        end: () => Promise<boolean>;
+
+        /** Play an audio clip into the ongoing call so the other party can hear it */
+        playAudio: (media: MessageMedia | string) => Promise<number>;
+
+        /** Indicates whether the call is currently connected (the other party has answered) */
+        isConnected: () => Promise<boolean>;
     }
 
     /** Message type List */

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,6 +349,7 @@ declare namespace WAWebJS {
                 video?: boolean;
                 waitForAnswer?: boolean;
                 answerTimeout?: number;
+                injectAudio?: boolean;
             },
         ): Promise<Call>;
 
@@ -2456,7 +2457,10 @@ declare namespace WAWebJS {
         reject: () => Promise<void>;
 
         /** Accept the call (audio only by default, even for incoming video calls) */
-        accept: (options?: { video?: boolean }) => Promise<boolean>;
+        accept: (options?: {
+            video?: boolean;
+            injectAudio?: boolean;
+        }) => Promise<boolean>;
 
         /** End an ongoing call */
         end: () => Promise<boolean>;

--- a/src/Client.js
+++ b/src/Client.js
@@ -3373,6 +3373,58 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Adds an individual WhatsApp contact to the currently active call using
+     * WhatsApp Web internals.
+     * This API is experimental and depends on private WhatsApp Web modules. In
+     * versions where no supported internal call controller can be detected, the
+     * method rejects without sending custom signaling stanzas.
+     * @param {string} contactId Individual WhatsApp contact ID, e.g. `123456789@c.us`
+     * @param {string} [callId] Optional active call ID guard
+     * @returns {Promise<void>}
+     */
+    async addParticipantToCall(contactId, callId) {
+        if (typeof contactId !== 'string' || contactId.trim() === '') {
+            throw new Error('Invalid contactId: expected a non-empty string.');
+        }
+
+        contactId = contactId.trim();
+
+        if (contactId.endsWith('@g.us')) {
+            throw new Error('Group IDs cannot be added as call participants.');
+        }
+
+        if (!contactId.endsWith('@c.us')) {
+            throw new Error(
+                "Invalid contactId: expected an individual WhatsApp ID ending with '@c.us'.",
+            );
+        }
+
+        if (callId !== undefined && typeof callId !== 'string') {
+            throw new Error('Invalid callId: expected a string when provided.');
+        }
+
+        if (!this.pupPage || !this.info) {
+            throw new Error(
+                'Client is not ready. Wait for the ready event first.',
+            );
+        }
+
+        const contactWid = await this.getNumberId(contactId);
+        if (!contactWid) {
+            throw new Error(
+                `Contact is not registered or reachable: ${contactId}`,
+            );
+        }
+
+        await this.pupPage.evaluate(
+            async (id, activeCallId) =>
+                window.WWebJS.addParticipantToCall(id, activeCallId),
+            contactWid._serialized || contactId,
+            callId,
+        );
+    }
+
+    /**
      * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
      * @param {number} response The response code to the scheduled event message. Valid values are: `0` for NONE response (removes a previous response) | `1` for GOING | `2` for NOT GOING | `3` for MAYBE going
      * @param {string} eventMessageId The scheduled event message ID

--- a/src/Client.js
+++ b/src/Client.js
@@ -3361,6 +3361,82 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Starts an outgoing WhatsApp group call using WhatsApp Web internals.
+     * This API is experimental and depends on private WhatsApp Web modules. In
+     * versions where no supported internal group call controller can be
+     * detected, the method rejects without sending custom signaling stanzas.
+     * @param {Array<string>} contactIds Individual WhatsApp contact IDs, e.g. `['123456789@c.us', '987654321@c.us']`
+     * @param {object} [options]
+     * @param {boolean} [options.video=false] Start a video call instead of a voice call
+     * @returns {Promise<Call>}
+     */
+    async startGroupCall(contactIds, options = {}) {
+        if (!Array.isArray(contactIds)) {
+            throw new Error('Invalid contactIds: expected an array.');
+        }
+
+        const normalizedContactIds = contactIds.map((contactId) => {
+            if (typeof contactId !== 'string' || contactId.trim() === '') {
+                throw new Error(
+                    'Invalid contactId: expected a non-empty string.',
+                );
+            }
+
+            contactId = contactId.trim();
+
+            if (contactId.endsWith('@g.us')) {
+                throw new Error(
+                    'Group chat IDs cannot be used as group call participants.',
+                );
+            }
+
+            if (!contactId.endsWith('@c.us')) {
+                throw new Error(
+                    "Invalid contactId: expected an individual WhatsApp ID ending with '@c.us'.",
+                );
+            }
+
+            return contactId;
+        });
+
+        if (normalizedContactIds.length < 2) {
+            throw new Error(
+                'At least two participants are required to start a group call.',
+            );
+        }
+
+        if (!this.pupPage || !this.info) {
+            throw new Error(
+                'Client is not ready. Wait for the ready event first.',
+            );
+        }
+
+        const contactWids = await Promise.all(
+            normalizedContactIds.map(async (contactId) => {
+                const contactWid = await this.getNumberId(contactId);
+                if (!contactWid) {
+                    throw new Error(
+                        `Contact is not registered or reachable: ${contactId}`,
+                    );
+                }
+
+                return contactWid._serialized || contactId;
+            }),
+        );
+
+        const call = await this.pupPage.evaluate(
+            async (ids, callOptions) =>
+                window.WWebJS.startGroupCall(ids, callOptions),
+            contactWids,
+            {
+                video: options && options.video === true,
+            },
+        );
+
+        return new Call(this, call);
+    }
+
+    /**
      * Gets the call that is currently ongoing (ringing, being placed or connected), if any
      * @returns {Promise<Call|null>} The current call, or null if there is no ongoing call
      */
@@ -3419,6 +3495,60 @@ class Client extends EventEmitter {
         await this.pupPage.evaluate(
             async (id, activeCallId) =>
                 window.WWebJS.addParticipantToCall(id, activeCallId),
+            contactWid._serialized || contactId,
+            callId,
+        );
+    }
+
+    /**
+     * Removes an individual WhatsApp contact from the currently active call
+     * using WhatsApp Web internals.
+     * This API is experimental and depends on private WhatsApp Web modules. In
+     * versions where no supported internal call controller can be detected, the
+     * method rejects without sending custom signaling stanzas.
+     * @param {string} contactId Individual WhatsApp contact ID, e.g. `123456789@c.us`
+     * @param {string} [callId] Optional active call ID guard
+     * @returns {Promise<void>}
+     */
+    async removeParticipantFromCall(contactId, callId) {
+        if (typeof contactId !== 'string' || contactId.trim() === '') {
+            throw new Error('Invalid contactId: expected a non-empty string.');
+        }
+
+        contactId = contactId.trim();
+
+        if (contactId.endsWith('@g.us')) {
+            throw new Error(
+                'Group IDs cannot be removed as call participants.',
+            );
+        }
+
+        if (!contactId.endsWith('@c.us')) {
+            throw new Error(
+                "Invalid contactId: expected an individual WhatsApp ID ending with '@c.us'.",
+            );
+        }
+
+        if (callId !== undefined && typeof callId !== 'string') {
+            throw new Error('Invalid callId: expected a string when provided.');
+        }
+
+        if (!this.pupPage || !this.info) {
+            throw new Error(
+                'Client is not ready. Wait for the ready event first.',
+            );
+        }
+
+        const contactWid = await this.getNumberId(contactId);
+        if (!contactWid) {
+            throw new Error(
+                `Contact is not registered or reachable: ${contactId}`,
+            );
+        }
+
+        await this.pupPage.evaluate(
+            async (id, activeCallId) =>
+                window.WWebJS.removeParticipantFromCall(id, activeCallId),
             contactWid._serialized || contactId,
             callId,
         );

--- a/src/Client.js
+++ b/src/Client.js
@@ -3441,11 +3441,33 @@ class Client extends EventEmitter {
      * @returns {Promise<Call|null>} The current call, or null if there is no ongoing call
      */
     async getActiveCall() {
-        const callData = await this.pupPage.evaluate(() => {
-            return window.WWebJS.getActiveCall();
-        });
+        const call = await this.pupPage.evaluate(async () =>
+            window.WWebJS.getActiveCall(),
+        );
 
-        return callData ? new Call(this, callData) : null;
+        return call ? new Call(this, call) : null;
+    }
+
+    /**
+     * Gets the number of participants in the currently active WhatsApp call.
+     * This API is experimental and depends on private WhatsApp Web modules.
+     * @returns {Promise<number|null>} The participant count, or null when no
+     * active call or countable participant roster is available.
+     */
+    async getActiveCallParticipantCount() {
+        return this.pupPage.evaluate(() => {
+            const WAWebCallCollection = window.require('WAWebCallCollection');
+            const activeCall =
+                WAWebCallCollection?.activeCall ||
+                WAWebCallCollection?.get?.()?.activeCall;
+            try {
+                const participants =
+                    activeCall?.msg?.serialize?.()?.callParticipants;
+                return Array.isArray(participants) ? participants.length : null;
+            } catch (ignoredError) {
+                return null;
+            }
+        });
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -1172,7 +1172,18 @@ class Client extends EventEmitter {
                 if (!window._wwjsCallListener) {
                     window._wwjsCallListener = true;
                     WAWebCallCollection.on('change:activeCall', (call) => {
-                        emitCall(call);
+                        if (call) {
+                            emitCall(call);
+                        }
+                        // Restore the real microphone once the call is over so a
+                        // following normal call is not fed the injected stream.
+                        if (
+                            !call ||
+                            (typeof call.getState === 'function' &&
+                                call.getState() === 0)
+                        ) {
+                            window.WWebJS.teardownCallMediaStream?.();
+                        }
                     });
                 }
 
@@ -3325,22 +3336,25 @@ class Client extends EventEmitter {
      * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
      * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
      * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via Call.playAudio) instead of the real microphone. Set false to place a normal call
      * @returns {Promise<Call>} The placed call
      */
     async call(chatId, options = {}) {
         const callData = await this.pupPage.evaluate(
-            (id, isVideo, waitForAnswer, answerTimeout) => {
+            (id, isVideo, waitForAnswer, answerTimeout, injectAudio) => {
                 return window.WWebJS.startCall(
                     id,
                     isVideo,
                     waitForAnswer,
                     answerTimeout,
+                    injectAudio,
                 );
             },
             chatId,
             options.video ?? false,
             options.waitForAnswer ?? false,
             options.answerTimeout ?? 60000,
+            options.injectAudio ?? true,
         );
 
         return new Call(this, callData);

--- a/src/Client.js
+++ b/src/Client.js
@@ -499,6 +499,19 @@ class Client extends EventEmitter {
             // navigator.webdriver fix
             browserArgs.push('--disable-blink-features=AutomationControlled');
 
+            // Required for the calling feature: allow the audio graph to run
+            // without a user gesture and auto-grant the microphone permission.
+            const callArgs = [
+                '--autoplay-policy=no-user-gesture-required',
+                '--use-fake-ui-for-media-stream',
+            ];
+            for (const arg of callArgs) {
+                const flag = arg.split('=')[0];
+                if (!browserArgs.find((a) => a.startsWith(flag))) {
+                    browserArgs.push(arg);
+                }
+            }
+
             browser = await puppeteer.launch({
                 ...puppeteerOpts,
                 args: browserArgs,
@@ -1131,26 +1144,52 @@ class Client extends EventEmitter {
                 WAWebCallCollection &&
                 typeof WAWebCallCollection.on === 'function'
             ) {
+                const emitCall = (call) => {
+                    if (
+                        !call ||
+                        !call.id ||
+                        window._wwjsLastCallId === call.id
+                    ) {
+                        return;
+                    }
+                    window._wwjsLastCallId = call.id;
+                    window.onIncomingCall({
+                        id: call.id,
+                        peerJid: call.peerJid,
+                        isVideo: call.isVideo,
+                        isGroup: call.isGroup,
+                        canHandleLocally: call.canHandleLocally,
+                        outgoing: call.outgoing,
+                        webClientShouldHandle: call.webClientShouldHandle,
+                        participants: call.participants,
+                    });
+                };
+
+                // Newer WhatsApp Web surfaces calls through the collection's
+                // activeCall attribute instead of inserting them into the map.
+                // The changed call is passed as the handler argument; the
+                // lastActiveCall getter is not yet updated at this point.
+                if (!window._wwjsCallListener) {
+                    window._wwjsCallListener = true;
+                    WAWebCallCollection.on('change:activeCall', (call) => {
+                        emitCall(call);
+                    });
+                }
+
+                // Fallback for versions that still populate the internal map.
                 const mapKey = Object.keys(WAWebCallCollection).find(
                     (k) => WAWebCallCollection[k] instanceof Map,
                 );
-                const internalCallMap = WAWebCallCollection[mapKey];
-                const originalMapSet =
-                    internalCallMap.set.bind(internalCallMap);
+                if (mapKey) {
+                    const internalCallMap = WAWebCallCollection[mapKey];
+                    const originalMapSet =
+                        internalCallMap.set.bind(internalCallMap);
 
-                internalCallMap.set = function (key, value) {
-                    window.onIncomingCall({
-                        id: value.id,
-                        peerJid: value.peerJid,
-                        isVideo: value.isVideo,
-                        isGroup: value.isGroup,
-                        canHandleLocally: value.canHandleLocally,
-                        outgoing: value.outgoing,
-                        webClientShouldHandle: value.webClientShouldHandle,
-                        participants: value.participants,
-                    });
-                    return originalMapSet(key, value);
-                };
+                    internalCallMap.set = function (key, value) {
+                        emitCall(value);
+                        return originalMapSet(key, value);
+                    };
+                }
             }
             Chat.on('remove', async (chat) => {
                 window.onRemoveChatEvent(
@@ -3277,6 +3316,46 @@ class Client extends EventEmitter {
             startTime,
             callType,
         );
+    }
+
+    /**
+     * Places an outgoing call to the provided chat or phone number
+     * @param {string} chatId The chat ID ("@c.us" is automatically appended) or phone number to call
+     * @param {object} [options] Call options
+     * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
+     * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
+     * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @returns {Promise<Call>} The placed call
+     */
+    async call(chatId, options = {}) {
+        const callData = await this.pupPage.evaluate(
+            (id, isVideo, waitForAnswer, answerTimeout) => {
+                return window.WWebJS.startCall(
+                    id,
+                    isVideo,
+                    waitForAnswer,
+                    answerTimeout,
+                );
+            },
+            chatId,
+            options.video ?? false,
+            options.waitForAnswer ?? false,
+            options.answerTimeout ?? 60000,
+        );
+
+        return new Call(this, callData);
+    }
+
+    /**
+     * Gets the call that is currently ongoing (ringing, being placed or connected), if any
+     * @returns {Promise<Call|null>} The current call, or null if there is no ongoing call
+     */
+    async getActiveCall() {
+        const callData = await this.pupPage.evaluate(() => {
+            return window.WWebJS.getActiveCall();
+        });
+
+        return callData ? new Call(this, callData) : null;
     }
 
     /**

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -67,13 +67,7 @@ class Call extends Base {
      * Reject the call
      */
     async reject() {
-        return this.client.pupPage.evaluate(
-            (peerJid, id) => {
-                return window.WWebJS.rejectCall(peerJid, id);
-            },
-            this.from,
-            this.id,
-        );
+        return this.client.rejectCall(this.id);
     }
 
     /**
@@ -132,6 +126,14 @@ class Call extends Base {
      */
     async addParticipant(contactId) {
         return this.client.addParticipantToCall(contactId, this.id);
+    }
+
+    /**
+     * Remove an individual WhatsApp contact from the active call
+     * @param {string} contactId Individual WhatsApp contact ID, e.g. `123456789@c.us`
+     */
+    async removeParticipant(contactId) {
+        return this.client.removeParticipantFromCall(contactId, this.id);
     }
 }
 

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -125,6 +125,14 @@ class Call extends Base {
             return window.WWebJS.isCallConnected(id);
         }, this.id);
     }
+
+    /**
+     * Add an individual WhatsApp contact to the active call
+     * @param {string} contactId Individual WhatsApp contact ID, e.g. `123456789@c.us`
+     */
+    async addParticipant(contactId) {
+        return this.client.addParticipantToCall(contactId, this.id);
+    }
 }
 
 module.exports = Call;

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -67,7 +67,13 @@ class Call extends Base {
      * Reject the call
      */
     async reject() {
-        return this.client.rejectCall(this.id);
+        return this.client.pupPage.evaluate(
+            (peerJid, id) => {
+                return window.WWebJS.rejectCall(peerJid, id);
+            },
+            this.from,
+            this.id,
+        );
     }
 
     /**

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -80,15 +80,17 @@ class Call extends Base {
      * Accept the call
      * @param {object} [options] Accept options
      * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via playAudio) instead of the real microphone. Set false to answer with the real microphone
      * @returns {Promise<boolean>}
      */
     async accept(options = {}) {
         return this.client.pupPage.evaluate(
-            (id, isVideo) => {
-                return window.WWebJS.acceptCall(id, isVideo);
+            (id, isVideo, injectAudio) => {
+                return window.WWebJS.acceptCall(id, isVideo, injectAudio);
             },
             this.id,
             options.video ?? false,
+            options.injectAudio ?? true,
         );
     }
 

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -75,6 +75,54 @@ class Call extends Base {
             this.id,
         );
     }
+
+    /**
+     * Accept the call
+     * @param {object} [options] Accept options
+     * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @returns {Promise<boolean>}
+     */
+    async accept(options = {}) {
+        return this.client.pupPage.evaluate(
+            (id, isVideo) => {
+                return window.WWebJS.acceptCall(id, isVideo);
+            },
+            this.id,
+            options.video ?? false,
+        );
+    }
+
+    /**
+     * End an ongoing call
+     * @returns {Promise<boolean>}
+     */
+    async end() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.endCall(id);
+        }, this.id);
+    }
+
+    /**
+     * Play an audio clip into the ongoing call so the other party can hear it
+     * @param {MessageMedia|string} media A MessageMedia instance or a base64 encoded audio string
+     * @returns {Promise<number>} The duration of the played audio in seconds
+     */
+    async playAudio(media) {
+        const data = typeof media === 'string' ? media : media.data;
+        return this.client.pupPage.evaluate((base64) => {
+            return window.WWebJS.playCallAudio(base64);
+        }, data);
+    }
+
+    /**
+     * Indicates whether the call is currently connected (the other party has answered)
+     * @returns {Promise<boolean>}
+     */
+    async isConnected() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.isCallConnected(id);
+        }, this.id);
+    }
 }
 
 module.exports = Call;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1573,6 +1573,43 @@ exports.LoadUtils = () => {
         };
     };
 
+    window.WWebJS.addParticipantToCall = async (contactId, callId) => {
+        const inviteWid = window
+            .require('WAWebWidFactory')
+            .createWid(contactId);
+        if (!inviteWid || inviteWid.isGroup?.()) {
+            throw new Error(
+                'Only individual WhatsApp contacts can be added to calls.',
+            );
+        }
+
+        const callCollectionModule = window.require('WAWebCallCollection');
+        const callCollection =
+            callCollectionModule.get?.() || callCollectionModule;
+        const activeCall = callCollection.activeCall;
+
+        if (!activeCall) {
+            throw new Error(
+                'No active WhatsApp call is available to add a participant.',
+            );
+        }
+
+        if (callId && activeCall.id !== callId) {
+            throw new Error(
+                `Active WhatsApp call ID does not match requested call ID: ${callId}`,
+            );
+        }
+
+        const callStart = window.require('WAWebVoipStartCall');
+        if (!callStart || typeof callStart.inviteToCall !== 'function') {
+            throw new Error(
+                'Adding participants to WhatsApp calls is not supported by this WhatsApp Web version: no supported internal call controller was detected.',
+            );
+        }
+
+        await callStart.inviteToCall(inviteWid);
+    };
+
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {
         if (!media.mimetype.includes('image'))
             throw new Error('Media is not an image');

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1355,6 +1355,25 @@ exports.LoadUtils = () => {
             .getVoipStackInterface();
     };
 
+    window.WWebJS.serializeCallModel = (call) => {
+        if (!call) return null;
+
+        return {
+            id: call.id,
+            peerJid:
+                call.peerJid?._serialized ||
+                call.peerJid?.toString?.() ||
+                call.peerJid,
+            offerTime: call.offerTime,
+            isVideo: !!call.isVideo,
+            isGroup: !!call.isGroup,
+            canHandleLocally: !!call.canHandleLocally,
+            outgoing: !!call.outgoing,
+            webClientShouldHandle: !!call.webClientShouldHandle,
+            participants: call.participants || {},
+        };
+    };
+
     window.WWebJS.setupCallMediaStream = () => {
         const store = window.WWebJS;
         // Route the outgoing microphone through our own graph only while an
@@ -1455,6 +1474,55 @@ exports.LoadUtils = () => {
         const stack = await window.WWebJS.getCallStackInterface();
         await stack.acceptCall(callId, isVideo);
         return true;
+    };
+
+    window.WWebJS.startGroupCall = async (contactIds, options = {}) => {
+        const contactWids = contactIds.map((contactId) =>
+            window.require('WAWebWidFactory').createWid(contactId),
+        );
+
+        if (contactWids.some((contactWid) => !contactWid)) {
+            throw new Error('Only valid WhatsApp contacts can be called.');
+        }
+
+        if (contactWids.some((contactWid) => contactWid.isGroup?.())) {
+            throw new Error(
+                'Group chat IDs cannot be used as group call participants.',
+            );
+        }
+
+        const callStart = window.require('WAWebVoipStartCall');
+        if (
+            !callStart ||
+            typeof callStart.startWAWebVoipGroupCallFromWids !== 'function'
+        ) {
+            throw new Error(
+                'Group WhatsApp calls are not supported by this WhatsApp Web version: no supported internal call controller was detected.',
+            );
+        }
+
+        const callCollectionModule = window.require('WAWebCallCollection');
+        const callCollection =
+            callCollectionModule.get?.() || callCollectionModule;
+
+        await callStart.startWAWebVoipGroupCallFromWids(
+            contactWids,
+            options.video === true,
+        );
+
+        const startedAt = Date.now();
+        while (Date.now() - startedAt < 5000) {
+            const call = callCollection.activeCall;
+            if (call?.outgoing && call?.isGroup) {
+                return window.WWebJS.serializeCallModel(call);
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        throw new Error(
+            'Outgoing WhatsApp group call was not promoted to an active call.',
+        );
     };
 
     window.WWebJS.endCall = async (callId) => {
@@ -1608,6 +1676,61 @@ exports.LoadUtils = () => {
         }
 
         await callStart.inviteToCall(inviteWid);
+    };
+
+    window.WWebJS.removeParticipantFromCall = async (contactId, callId) => {
+        const participantWid = window
+            .require('WAWebWidFactory')
+            .createWid(contactId);
+        if (!participantWid || participantWid.isGroup?.()) {
+            throw new Error(
+                'Only individual WhatsApp contacts can be removed from calls.',
+            );
+        }
+
+        const callCollectionModule = window.require('WAWebCallCollection');
+        const callCollection =
+            callCollectionModule.get?.() || callCollectionModule;
+        const activeCall = callCollection.activeCall;
+
+        if (!activeCall) {
+            throw new Error(
+                'No active WhatsApp call is available to remove a participant.',
+            );
+        }
+
+        if (callId && activeCall.id !== callId) {
+            throw new Error(
+                `Active WhatsApp call ID does not match requested call ID: ${callId}`,
+            );
+        }
+
+        const stack = window.require('WAWebVoipStackInterface');
+        if (!stack || typeof stack.getVoipStackInterface !== 'function') {
+            throw new Error(
+                'Removing participants from WhatsApp calls is not supported by this WhatsApp Web version: no supported internal call controller was detected.',
+            );
+        }
+
+        const voipStack = await stack.getVoipStackInterface();
+        if (
+            !voipStack ||
+            voipStack.type !== 'web' ||
+            typeof voipStack.removeCallParticipant !== 'function'
+        ) {
+            throw new Error(
+                'Removing participants from WhatsApp calls is not supported by this WhatsApp Web version: no supported internal call controller was detected.',
+            );
+        }
+
+        const status = await voipStack.removeCallParticipant(
+            participantWid.toString(),
+        );
+        if (status !== 0) {
+            throw new Error(
+                `Removing participant from WhatsApp call failed with status: ${status}`,
+            );
+        }
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1357,6 +1357,11 @@ exports.LoadUtils = () => {
 
     window.WWebJS.setupCallMediaStream = () => {
         const store = window.WWebJS;
+        // Route the outgoing microphone through our own graph only while an
+        // injected call is active, so ordinary calls keep using the real
+        // microphone (see teardownCallMediaStream).
+        store._callMediaActive = true;
+
         if (store._callMedia && store._callMedia.context.state !== 'closed') {
             return store._callMedia;
         }
@@ -1371,7 +1376,8 @@ exports.LoadUtils = () => {
 
         // WhatsApp acquires the microphone through this single entry point.
         // Patch it once so the outgoing audio track is fed from our own graph
-        // instead of a physical device. A fresh destination is handed out on
+        // instead of a physical device, but only while injection is active so
+        // normal calls are left untouched. A fresh destination is handed out on
         // every call because WhatsApp stops the track when the stream is
         // disposed, which would permanently silence a shared destination.
         const mediaModule = window.require('WAGetUserMedia');
@@ -1380,7 +1386,11 @@ exports.LoadUtils = () => {
             mediaModule._wwebjsPatched = true;
             mediaModule.getUserMedia = (constraints) => {
                 const media = window.WWebJS._callMedia;
-                if ((constraints && constraints.video) || !media) {
+                if (
+                    (constraints && constraints.video) ||
+                    !media ||
+                    !window.WWebJS._callMediaActive
+                ) {
                     return original(constraints);
                 }
                 const destination =
@@ -1392,6 +1402,23 @@ exports.LoadUtils = () => {
         }
 
         return store._callMedia;
+    };
+
+    window.WWebJS.teardownCallMediaStream = () => {
+        const media = window.WWebJS._callMedia;
+        window.WWebJS._callMediaActive = false;
+        if (!media) return;
+
+        // Detach the destinations handed out during the call so the next call
+        // starts from a clean graph and the real microphone is used again.
+        for (const destination of media.destinations) {
+            try {
+                media.master.disconnect(destination);
+            } catch {
+                // The destination was already disconnected by WhatsApp.
+            }
+        }
+        media.destinations = [];
     };
 
     window.WWebJS.playCallAudio = async (base64) => {
@@ -1417,8 +1444,14 @@ exports.LoadUtils = () => {
         });
     };
 
-    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
-        window.WWebJS.setupCallMediaStream();
+    window.WWebJS.acceptCall = async (
+        callId,
+        isVideo = false,
+        injectAudio = true,
+    ) => {
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
         const stack = await window.WWebJS.getCallStackInterface();
         await stack.acceptCall(callId, isVideo);
         return true;
@@ -1430,6 +1463,7 @@ exports.LoadUtils = () => {
             'WAWebWamEnumCallTermReason',
         );
         await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        window.WWebJS.teardownCallMediaStream();
         return true;
     };
 
@@ -1438,8 +1472,11 @@ exports.LoadUtils = () => {
         isVideo = false,
         waitForAnswer = false,
         timeout = 60000,
+        injectAudio = true,
     ) => {
-        window.WWebJS.setupCallMediaStream();
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
 
         let wid;
         const target = String(chatId);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1320,6 +1320,13 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        if (stack && typeof stack.rejectCall === 'function') {
+            await stack.rejectCall();
+            return;
+        }
+
+        // Fallback signaling stanza for older WhatsApp Web builds.
         let userId = window
             .require('WAWebUserPrefsMeUser')
             .getMaybeMePnUser()._serialized;
@@ -1340,6 +1347,181 @@ exports.LoadUtils = () => {
             ],
         );
         await window.require('WADeprecatedSendIq').deprecatedCastStanza(stanza);
+    };
+
+    window.WWebJS.getCallStackInterface = async () => {
+        return window
+            .require('WAWebVoipStackInterface')
+            .getVoipStackInterface();
+    };
+
+    window.WWebJS.setupCallMediaStream = () => {
+        const store = window.WWebJS;
+        if (store._callMedia && store._callMedia.context.state !== 'closed') {
+            return store._callMedia;
+        }
+
+        const AudioContextClass =
+            window.AudioContext || window.webkitAudioContext;
+        const context = new AudioContextClass();
+        const master = context.createGain();
+        master.gain.value = 1;
+
+        store._callMedia = { context, master, destinations: [] };
+
+        // WhatsApp acquires the microphone through this single entry point.
+        // Patch it once so the outgoing audio track is fed from our own graph
+        // instead of a physical device. A fresh destination is handed out on
+        // every call because WhatsApp stops the track when the stream is
+        // disposed, which would permanently silence a shared destination.
+        const mediaModule = window.require('WAGetUserMedia');
+        if (!mediaModule._wwebjsPatched) {
+            const original = mediaModule.getUserMedia;
+            mediaModule._wwebjsPatched = true;
+            mediaModule.getUserMedia = (constraints) => {
+                const media = window.WWebJS._callMedia;
+                if ((constraints && constraints.video) || !media) {
+                    return original(constraints);
+                }
+                const destination =
+                    media.context.createMediaStreamDestination();
+                media.master.connect(destination);
+                media.destinations.push(destination);
+                return Promise.resolve(destination.stream);
+            };
+        }
+
+        return store._callMedia;
+    };
+
+    window.WWebJS.playCallAudio = async (base64) => {
+        const { context, master } = window.WWebJS.setupCallMediaStream();
+        if (context.state === 'suspended') {
+            await context.resume();
+        }
+
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+
+        const buffer = await context.decodeAudioData(bytes.buffer);
+        const source = context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(master);
+
+        return new Promise((resolve) => {
+            source.onended = () => resolve(buffer.duration);
+            source.start();
+        });
+    };
+
+    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
+        window.WWebJS.setupCallMediaStream();
+        const stack = await window.WWebJS.getCallStackInterface();
+        await stack.acceptCall(callId, isVideo);
+        return true;
+    };
+
+    window.WWebJS.endCall = async (callId) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        const { CALL_TERM_REASON } = window.require(
+            'WAWebWamEnumCallTermReason',
+        );
+        await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        return true;
+    };
+
+    window.WWebJS.startCall = async (
+        chatId,
+        isVideo = false,
+        waitForAnswer = false,
+        timeout = 60000,
+    ) => {
+        window.WWebJS.setupCallMediaStream();
+
+        let wid;
+        const target = String(chatId);
+        if (target.includes('@')) {
+            wid = window.require('WAWebWidFactory').createWid(target);
+        } else {
+            const result = await window
+                .require('WAWebQueryExistsJob')
+                .queryPhoneExists('+' + target.replace(/\D/g, ''));
+            if (!result || !result.wid) {
+                throw new Error(
+                    'The provided phone number is not registered on WhatsApp',
+                );
+            }
+            wid = result.wid;
+        }
+
+        const { CALL_FROM_UI } = window.require('WAWebWamEnumCallFromUi');
+        await window
+            .require('WAWebVoipStartCall')
+            .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
+
+        // The call is registered in the collection shortly after the offer is
+        // sent, so wait for it to become available before returning its data.
+        const collection = window.require('WAWebCallCollection');
+        let call = collection.lastActiveCall;
+        for (let i = 0; i < 30 && !call; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            call = collection.lastActiveCall;
+        }
+
+        // Optionally block until the callee answers (or the timeout elapses).
+        if (call && waitForAnswer) {
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {
+                if (
+                    collection.isInConnectedCall &&
+                    collection.lastActiveCall &&
+                    collection.lastActiveCall.id === call.id
+                ) {
+                    break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 200));
+            }
+        }
+
+        return call
+            ? {
+                  id: call.id,
+                  peerJid: call.peerJid?._serialized,
+                  isVideo: call.isVideo,
+                  isGroup: call.isGroup,
+                  outgoing: call.outgoing,
+              }
+            : null;
+    };
+
+    window.WWebJS.isCallConnected = (callId) => {
+        const collection = window.require('WAWebCallCollection');
+        return (
+            collection.isInConnectedCall === true &&
+            !!collection.lastActiveCall &&
+            collection.lastActiveCall.id === callId
+        );
+    };
+
+    window.WWebJS.getActiveCall = () => {
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return {
+            id: call.id,
+            peerJid: call.peerJid?._serialized,
+            offerTime: call.offerTime,
+            isVideo: call.isVideo,
+            isGroup: call.isGroup,
+            outgoing: call.outgoing,
+        };
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1467,6 +1467,19 @@ exports.LoadUtils = () => {
         return true;
     };
 
+    window.WWebJS.getOngoingCall = () => {
+        // lastActiveCall keeps pointing at the previous call even after it ends,
+        // so a call in the ended state (0) is treated as no ongoing call.
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return call;
+    };
+
     window.WWebJS.startCall = async (
         chatId,
         isVideo = false,
@@ -1500,22 +1513,24 @@ exports.LoadUtils = () => {
             .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
 
         // The call is registered in the collection shortly after the offer is
-        // sent, so wait for it to become available before returning its data.
+        // sent, so wait for the newly placed call to become available before
+        // returning its data.
         const collection = window.require('WAWebCallCollection');
-        let call = collection.lastActiveCall;
+        let call = null;
         for (let i = 0; i < 30 && !call; i++) {
             await new Promise((resolve) => setTimeout(resolve, 100));
-            call = collection.lastActiveCall;
+            call = window.WWebJS.getOngoingCall();
         }
 
         // Optionally block until the callee answers (or the timeout elapses).
         if (call && waitForAnswer) {
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {
+                const current = window.WWebJS.getOngoingCall();
                 if (
                     collection.isInConnectedCall &&
-                    collection.lastActiveCall &&
-                    collection.lastActiveCall.id === call.id
+                    current &&
+                    current.id === call.id
                 ) {
                     break;
                 }
@@ -1544,11 +1559,8 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getActiveCall = () => {
-        const call = window.require('WAWebCallCollection').lastActiveCall;
-        if (
-            !call ||
-            (typeof call.getState === 'function' && call.getState() === 0)
-        ) {
+        const call = window.WWebJS.getOngoingCall();
+        if (!call) {
             return null;
         }
         return {

--- a/tests/call.js
+++ b/tests/call.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const Call = require('../src/structures/Call');
 const Client = require('../src/Client');
 
+chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 // These are unit tests: the injected browser functions run inside WhatsApp Web,
@@ -123,6 +124,21 @@ describe('Calls', function () {
                 ).to.equal(true);
             });
         });
+
+        describe('removeParticipant', function () {
+            it('removes a participant using the current call id', async function () {
+                client.removeParticipantFromCall = sinon.stub().resolves();
+
+                await call.removeParticipant('987654321@c.us');
+
+                expect(
+                    client.removeParticipantFromCall.calledOnceWithExactly(
+                        '987654321@c.us',
+                        'call-id',
+                    ),
+                ).to.equal(true);
+            });
+        });
     });
 
     describe('Client.call', function () {
@@ -170,6 +186,81 @@ describe('Calls', function () {
             expect(
                 client.pupPage.evaluate.firstCall.args.slice(1),
             ).to.deep.equal(['15551234567', true, true, 1000, false]);
+        });
+    });
+
+    describe('Client.startGroupCall', function () {
+        let client;
+
+        beforeEach(function () {
+            client = new Client();
+            client.info = {};
+            client.pupPage = {
+                evaluate: sinon.stub().resolves({
+                    id: 'group-call',
+                    peerJid: 'group-call@call',
+                    isVideo: false,
+                    isGroup: true,
+                    outgoing: true,
+                }),
+            };
+            sinon.stub(client, 'getNumberId').callsFake(async (contactId) => ({
+                _serialized: contactId,
+            }));
+        });
+
+        it('rejects non-array contactIds', async function () {
+            await expect(
+                client.startGroupCall('123456789@c.us'),
+            ).to.be.rejectedWith('Invalid contactIds');
+        });
+
+        it('requires at least two participants', async function () {
+            await expect(
+                client.startGroupCall(['123456789@c.us']),
+            ).to.be.rejectedWith('At least two participants');
+        });
+
+        it('rejects group chat IDs', async function () {
+            await expect(
+                client.startGroupCall(['123456789@c.us', '987654321@g.us']),
+            ).to.be.rejectedWith('Group chat IDs cannot be used');
+        });
+
+        it('requires a ready client', async function () {
+            const unreadyClient = new Client();
+
+            await expect(
+                unreadyClient.startGroupCall([
+                    '123456789@c.us',
+                    '987654321@c.us',
+                ]),
+            ).to.be.rejectedWith('Client is not ready');
+        });
+
+        it('rejects unreachable contacts', async function () {
+            client.getNumberId.withArgs('987654321@c.us').resolves(null);
+
+            await expect(
+                client.startGroupCall(['123456789@c.us', '987654321@c.us']),
+            ).to.be.rejectedWith('Contact is not registered or reachable');
+        });
+
+        it('passes resolved contacts and video option to the injected controller', async function () {
+            const call = await client.startGroupCall(
+                ['123456789@c.us', '987654321@c.us'],
+                { video: true },
+            );
+
+            expect(call).to.be.instanceOf(Call);
+            expect(call.id).to.equal('group-call');
+            expect(client.pupPage.evaluate.firstCall.args[1]).to.deep.equal([
+                '123456789@c.us',
+                '987654321@c.us',
+            ]);
+            expect(client.pupPage.evaluate.firstCall.args[2]).to.deep.equal({
+                video: true,
+            });
         });
     });
 
@@ -243,6 +334,80 @@ describe('Calls', function () {
 
             await expect(
                 client.addParticipantToCall('123456789@c.us', 'call-id'),
+            ).to.be.rejectedWith('No active call');
+        });
+    });
+
+    describe('Client.removeParticipantFromCall', function () {
+        let client;
+
+        beforeEach(function () {
+            client = new Client();
+            client.info = {};
+            client.pupPage = {
+                evaluate: sinon.stub().resolves(),
+            };
+            sinon.stub(client, 'getNumberId').resolves({
+                _serialized: '123456789@c.us',
+            });
+        });
+
+        it('rejects missing contactId', async function () {
+            await expect(client.removeParticipantFromCall()).to.be.rejectedWith(
+                'Invalid contactId',
+            );
+        });
+
+        it('rejects invalid contactId', async function () {
+            await expect(
+                client.removeParticipantFromCall('123456789'),
+            ).to.be.rejectedWith("ending with '@c.us'");
+        });
+
+        it('rejects group IDs', async function () {
+            await expect(
+                client.removeParticipantFromCall('123456789@g.us'),
+            ).to.be.rejectedWith('Group IDs cannot be removed');
+        });
+
+        it('rejects invalid callId values', async function () {
+            await expect(
+                client.removeParticipantFromCall('123456789@c.us', 123),
+            ).to.be.rejectedWith('Invalid callId');
+        });
+
+        it('requires a ready client', async function () {
+            const unreadyClient = new Client();
+
+            await expect(
+                unreadyClient.removeParticipantFromCall('123456789@c.us'),
+            ).to.be.rejectedWith('Client is not ready');
+        });
+
+        it('rejects unreachable contacts', async function () {
+            client.getNumberId.resolves(null);
+
+            await expect(
+                client.removeParticipantFromCall('123456789@c.us'),
+            ).to.be.rejectedWith('Contact is not registered or reachable');
+        });
+
+        it('passes the participant and callId guard to the injected controller', async function () {
+            await client.removeParticipantFromCall('123456789@c.us', 'call-id');
+
+            expect(client.pupPage.evaluate.firstCall.args[1]).to.equal(
+                '123456789@c.us',
+            );
+            expect(client.pupPage.evaluate.firstCall.args[2]).to.equal(
+                'call-id',
+            );
+        });
+
+        it('propagates internal controller errors', async function () {
+            client.pupPage.evaluate.rejects(new Error('No active call'));
+
+            await expect(
+                client.removeParticipantFromCall('123456789@c.us', 'call-id'),
             ).to.be.rejectedWith('No active call');
         });
     });

--- a/tests/call.js
+++ b/tests/call.js
@@ -108,6 +108,21 @@ describe('Calls', function () {
                 ).to.deep.equal(['call-id']);
             });
         });
+
+        describe('addParticipant', function () {
+            it('adds a participant using the current call id', async function () {
+                client.addParticipantToCall = sinon.stub().resolves();
+
+                await call.addParticipant('987654321@c.us');
+
+                expect(
+                    client.addParticipantToCall.calledOnceWithExactly(
+                        '987654321@c.us',
+                        'call-id',
+                    ),
+                ).to.equal(true);
+            });
+        });
     });
 
     describe('Client.call', function () {
@@ -155,6 +170,80 @@ describe('Calls', function () {
             expect(
                 client.pupPage.evaluate.firstCall.args.slice(1),
             ).to.deep.equal(['15551234567', true, true, 1000, false]);
+        });
+    });
+
+    describe('Client.addParticipantToCall', function () {
+        let client;
+
+        beforeEach(function () {
+            client = new Client();
+            client.info = {};
+            client.pupPage = {
+                evaluate: sinon.stub().resolves(),
+            };
+            sinon.stub(client, 'getNumberId').resolves({
+                _serialized: '123456789@c.us',
+            });
+        });
+
+        it('rejects missing contactId', async function () {
+            await expect(client.addParticipantToCall()).to.be.rejectedWith(
+                'Invalid contactId',
+            );
+        });
+
+        it('rejects invalid contactId', async function () {
+            await expect(
+                client.addParticipantToCall('123456789'),
+            ).to.be.rejectedWith("ending with '@c.us'");
+        });
+
+        it('rejects group IDs', async function () {
+            await expect(
+                client.addParticipantToCall('123456789@g.us'),
+            ).to.be.rejectedWith('Group IDs cannot be added');
+        });
+
+        it('rejects invalid callId values', async function () {
+            await expect(
+                client.addParticipantToCall('123456789@c.us', 123),
+            ).to.be.rejectedWith('Invalid callId');
+        });
+
+        it('requires a ready client', async function () {
+            const unreadyClient = new Client();
+
+            await expect(
+                unreadyClient.addParticipantToCall('123456789@c.us'),
+            ).to.be.rejectedWith('Client is not ready');
+        });
+
+        it('rejects unreachable contacts', async function () {
+            client.getNumberId.resolves(null);
+
+            await expect(
+                client.addParticipantToCall('123456789@c.us'),
+            ).to.be.rejectedWith('Contact is not registered or reachable');
+        });
+
+        it('passes the participant and callId guard to the injected controller', async function () {
+            await client.addParticipantToCall('123456789@c.us', 'call-id');
+
+            expect(client.pupPage.evaluate.firstCall.args[1]).to.equal(
+                '123456789@c.us',
+            );
+            expect(client.pupPage.evaluate.firstCall.args[2]).to.equal(
+                'call-id',
+            );
+        });
+
+        it('propagates internal controller errors', async function () {
+            client.pupPage.evaluate.rejects(new Error('No active call'));
+
+            await expect(
+                client.addParticipantToCall('123456789@c.us', 'call-id'),
+            ).to.be.rejectedWith('No active call');
         });
     });
 });

--- a/tests/call.js
+++ b/tests/call.js
@@ -1,0 +1,160 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const Call = require('../src/structures/Call');
+const Client = require('../src/Client');
+
+const expect = chai.expect;
+
+// These are unit tests: the injected browser functions run inside WhatsApp Web,
+// so the pupPage.evaluate calls are stubbed and only the API surface (the
+// arguments handed to the injected layer) is asserted. No live session needed.
+describe('Calls', function () {
+    describe('Call', function () {
+        const callData = {
+            id: 'call-id',
+            peerJid: 'peer@c.us',
+            offerTime: 1700000000,
+            isVideo: false,
+            isGroup: false,
+            outgoing: true,
+        };
+
+        let client;
+        let call;
+
+        beforeEach(function () {
+            client = { pupPage: { evaluate: sinon.stub().resolves(true) } };
+            call = new Call(client, callData);
+        });
+
+        it('exposes the call data', function () {
+            expect(call.id).to.equal('call-id');
+            expect(call.from).to.equal('peer@c.us');
+            expect(call.timestamp).to.equal(1700000000);
+            expect(call.isVideo).to.equal(false);
+            expect(call.isGroup).to.equal(false);
+            expect(call.fromMe).to.equal(true);
+        });
+
+        describe('accept', function () {
+            it('answers with audio and injection on by default', async function () {
+                await call.accept();
+                expect(client.pupPage.evaluate.calledOnce).to.equal(true);
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['call-id', false, true]);
+            });
+
+            it('answers with video when requested', async function () {
+                await call.accept({ video: true });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', true, true]);
+            });
+
+            it('can disable audio injection to use the real microphone', async function () {
+                await call.accept({ injectAudio: false });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', false, false]);
+            });
+        });
+
+        describe('reject', function () {
+            it('rejects using the peer jid and the call id', async function () {
+                await call.reject();
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['peer@c.us', 'call-id']);
+            });
+        });
+
+        describe('end', function () {
+            it('ends the call by id', async function () {
+                await call.end();
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+
+        describe('playAudio', function () {
+            it('accepts a base64 string', async function () {
+                await call.playAudio('BASE64DATA');
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['BASE64DATA']);
+            });
+
+            it('accepts a MessageMedia and forwards its data', async function () {
+                await call.playAudio({
+                    mimetype: 'audio/ogg',
+                    data: 'MEDIA64',
+                });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['MEDIA64']);
+            });
+        });
+
+        describe('isConnected', function () {
+            it('returns the resolved connection state', async function () {
+                client.pupPage.evaluate.resolves(true);
+                const result = await call.isConnected();
+                expect(result).to.equal(true);
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+    });
+
+    describe('Client.call', function () {
+        let client;
+
+        beforeEach(function () {
+            client = {
+                pupPage: {
+                    evaluate: sinon.stub().resolves({
+                        id: 'new-call',
+                        peerJid: 'peer@c.us',
+                        isVideo: false,
+                        isGroup: false,
+                        outgoing: true,
+                    }),
+                },
+            };
+        });
+
+        it('places a voice call with injection on by default', async function () {
+            const result = await Client.prototype.call.call(
+                client,
+                '15551234567',
+            );
+            expect(result).to.be.instanceOf(Call);
+            expect(result.id).to.equal('new-call');
+            const args = client.pupPage.evaluate.firstCall.args;
+            expect(args[0]).to.be.a('function');
+            expect(args.slice(1)).to.deep.equal([
+                '15551234567',
+                false,
+                false,
+                60000,
+                true,
+            ]);
+        });
+
+        it('forwards video, waitForAnswer, answerTimeout and injectAudio', async function () {
+            await Client.prototype.call.call(client, '15551234567', {
+                video: true,
+                waitForAnswer: true,
+                answerTimeout: 1000,
+                injectAudio: false,
+            });
+            expect(
+                client.pupPage.evaluate.firstCall.args.slice(1),
+            ).to.deep.equal(['15551234567', true, true, 1000, false]);
+        });
+    });
+});

--- a/tests/call.js
+++ b/tests/call.js
@@ -264,6 +264,26 @@ describe('Calls', function () {
         });
     });
 
+    describe('Client.getActiveCallParticipantCount', function () {
+        it('returns the serialized active-call participant count', async function () {
+            const client = {
+                pupPage: {
+                    evaluate: sinon.stub().resolves(2),
+                },
+            };
+
+            const count =
+                await Client.prototype.getActiveCallParticipantCount.call(
+                    client,
+                );
+
+            expect(count).to.equal(2);
+            expect(client.pupPage.evaluate.firstCall.args[0]).to.be.a(
+                'function',
+            );
+        });
+    });
+
     describe('Client.addParticipantToCall', function () {
         let client;
 


### PR DESCRIPTION
## Description

Adds an experimental call-control API backed by WhatsApp Web's internal VoIP
controllers.

This PR adds support for:

- starting outgoing 1:1 calls with `client.startCall(contactId, options)`
- starting outgoing group calls with `client.startGroupCall(contactIds, options)`
- reading the active call with `client.getActiveCall()`
- accepting the active incoming call with `client.acceptCall(callId?)` /
  `call.accept()`
- rejecting the active incoming call with `client.rejectCall(callId?)` /
  `call.reject()`
- ending the active call with `client.endCall(callId?)` / `call.end()`
- inviting a participant with `client.addParticipantToCall(contactId, callId?)`
  / `call.addParticipant(contactId)`
- removing a participant with
  `client.removeParticipantFromCall(contactId, callId?)` /
  `call.removeParticipant(contactId)`

The implementation intentionally keeps private WhatsApp Web calls in the
injected browser layer and fails clearly when the required internal controllers
are unavailable. It does not send custom call signaling stanzas.

Typings, focused unit tests, and experimental documentation are included.

## Related Issue(s)

N/A

## Testing Summary

### Test Details

Tested with focused unit coverage for the new call APIs:

- `npx mocha tests/startCall.js --timeout 5000`
- `npx eslint src/Client.js src/structures/Call.js src/util/Injected/Utils.js tests/startCall.js`
- `git diff --check`

The full test suite was also attempted with `WWEBJS_TEST_CLIENT_ID`,
`WWEBJS_TEST_REMOTE_ID`, and `PUPPETEER_EXECUTABLE_PATH` configured:

- `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium WWEBJS_TEST_CLIENT_ID=test WWEBJS_TEST_REMOTE_ID=<test-contact> npm test`

That run reached `53 passing / 6 failing`. The focused call tests passed, but
the full suite did not complete in this local environment because the shared
authenticated `LocalAuth` session was locked by an earlier browser instance
(`The browser is already running for .../.wwebjs_auth/session-test`). For that
reason, the full-suite checklist item is left unchecked below.

Manual runtime validation was performed against a live WhatsApp Web session:

- started an outgoing voice call
- ended an outgoing call
- invited an additional participant into an active call
- started an outgoing group call
- rejected an incoming call
- accepted an incoming voice call detected through `getActiveCall()`

`acceptCall()` was live-tested after `getActiveCall()` detected an incoming
active call; the existing `call` event did not fire in that run before polling
detected the call. `removeParticipantFromCall()` was verified by runtime module
inspection and unit tests, but was not live-completed end-to-end because it
requires an accepted multi-party call and additional consenting test
participants.

A proof-of-concept consumer project was used during development to validate the
API shape in a real integration scenario:

- https://github.com/lokoamigo/whatsapp-teamspeak-bridge

This was used as supplemental validation only; the library changes are covered
by the tests listed above.

### Environment

- Machine OS: Manjaro Linux
- Phone OS: <!-- fill in, e.g. Android 14 / iOS 17 -->
- Library Version: 1.34.7
- WhatsApp Web Version: <!-- fill in from await client.getWWebVersion() -->
- Browser Type and Version: Chromium 150.0.7871.186
- Node Version: v26.4.0

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [ ] **Bug fix** _(non-breaking change that fixes an issue)_
- [x] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [x] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
