### PR TITLE
fix(client): prevent concurrent injection crash

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -103,6 +103,9 @@ class Client extends EventEmitter {
 
         this.currentIndexHtml = null;
         this.lastLoggedOut = false;
+        // Keep injection work isolated per Client. Different Client instances
+        // still inject in parallel, while calls for this page are serialized.
+        this._injectQueue = Promise.resolve();
 
         Util.setFfmpegPath(this.options.ffmpegPath);
     }
@@ -111,9 +114,15 @@ class Client extends EventEmitter {
      * Injection logic
      * Private function
      */
-    async inject() {
-        // Cancel any previous inject still running
-        if (this._injectAbort) this._injectAbort.abort();
+    inject() {
+        const injection = this._injectQueue
+            .catch(() => undefined)
+            .then(() => this._inject());
+        this._injectQueue = injection;
+        return injection;
+    }
+
+    async _inject() {
         const abort = new AbortController();
         this._injectAbort = abort;
 
@@ -174,7 +183,10 @@ class Client extends EventEmitter {
                     await this.destroy();
                     if (restart) {
                         // session restore failed so try again but without session to force new authentication
-                        return this.initialize();
+                        // This restart is already running inside the per-client
+                        // injection queue, so inject directly to avoid waiting
+                        // for the queue entry that is currently executing.
+                        return this.initialize({ bypassInjectQueue: true });
                     }
                     return;
                 }
@@ -466,7 +478,7 @@ class Client extends EventEmitter {
     /**
      * Sets up events and requirements, kicks off authentication request
      */
-    async initialize() {
+    async initialize({ bypassInjectQueue = false } = {}) {
         let /**
              * @type {puppeteer.Browser}
              */
@@ -534,35 +546,48 @@ class Client extends EventEmitter {
         // interrupts inject, the handler triggers a fresh inject.
         this._registerFramenavigatedHandler();
 
-        await this.inject();
+        if (bypassInjectQueue) {
+            await this._inject();
+        } else {
+            await this.inject();
+        }
     }
 
     _registerFramenavigatedHandler() {
         if (this._framenavigatedRegistered) return;
         this._framenavigatedRegistered = true;
 
-        this.pupPage.on('framenavigated', async (frame) => {
-            if (frame.parentFrame() !== null) return;
-
-            const isLogout =
-                frame.url().includes('post_logout=1') || this.lastLoggedOut;
-
-            if (isLogout) {
-                this.emit(Events.DISCONNECTED, 'LOGOUT');
-                await this.authStrategy.logout();
-                await this.authStrategy.beforeBrowserInitialized();
-                await this.authStrategy.afterBrowserInitialized();
-                this.lastLoggedOut = false;
-            }
-
-            const storeAvailable = await this.pupPage.evaluate(() => {
-                return typeof window.WWebJS !== 'undefined';
+        this.pupPage.on('framenavigated', (frame) => {
+            this._handleFrameNavigated(frame).catch((error) => {
+                // EventEmitter does not handle rejected promises returned by
+                // async listeners. Surface the client error without turning it
+                // into an unhandled rejection that terminates Node.js.
+                this.emit('inject_error', error);
             });
-
-            if (!isLogout && storeAvailable) return;
-
-            await this.inject();
         });
+    }
+
+    async _handleFrameNavigated(frame) {
+        if (frame.parentFrame() !== null) return;
+
+        const isLogout =
+            frame.url().includes('post_logout=1') || this.lastLoggedOut;
+
+        if (isLogout) {
+            this.emit(Events.DISCONNECTED, 'LOGOUT');
+            await this.authStrategy.logout();
+            await this.authStrategy.beforeBrowserInitialized();
+            await this.authStrategy.afterBrowserInitialized();
+            this.lastLoggedOut = false;
+        }
+
+        const storeAvailable = await this.pupPage.evaluate(() => {
+            return typeof window.WWebJS !== 'undefined';
+        });
+
+        if (!isLogout && storeAvailable) return;
+
+        await this.inject();
     }
 
     /**

--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -17,7 +17,20 @@ async function exposeFunctionIfAbsent(page, name, fn) {
     if (exist) {
         return;
     }
-    await page.exposeFunction(name, fn);
+    try {
+        await page.exposeFunction(name, fn);
+    } catch (error) {
+        // The page may register the binding between evaluate() and
+        // exposeFunction(). Treat only that known race as an idempotent result.
+        const message = error?.message || String(error);
+        if (
+            message.includes(`binding with name ${name}`) &&
+            message.includes('already exists')
+        ) {
+            return;
+        }
+        throw error;
+    }
 }
 
 module.exports = { exposeFunctionIfAbsent };


### PR DESCRIPTION
## Problem

Concurrent `Client.inject()` calls can reach `exposeFunctionIfAbsent()` at the
same time during page navigation or authentication.

Because checking `window[name]` and calling `page.exposeFunction()` are separate
operations, both calls can pass the check. The second registration then throws:

```text
Failed to add page binding with name onQRChangedEvent:
window['onQRChangedEvent'] already exists!
```

The error can escape from the async `framenavigated` listener as an unhandled
rejection and terminate the Node.js process.

## Changes

- Serialize `inject()` calls per `Client` instance.
- Preserve parallel initialization between different clients.
- Avoid a queue deadlock during authentication recovery.
- Treat only the known duplicate Puppeteer binding error as idempotent.
- Catch failures from the async `framenavigated` flow and emit `inject_error`.
- Continue propagating unrelated Puppeteer errors.

## Testing

- `node --check src/Client.js`
- `node --check src/util/Puppeteer.js`
- `git diff --check`
- Verified that the duplicate binding error is ignored.
- Verified that unrelated Puppeteer errors still propagate.

A live WhatsApp session is still required for full QR/logout/reconnect testing.
