### PR TITLE
fix(groupchat): fix setDescription argument

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -404,23 +404,23 @@ class GroupChat extends Chat {
     async setDescription(description) {
         const success = await this.client.pupPage.evaluate(
             async (chatId, description) => {
-                const chatWid = window
+                const chatWid = await window
                     .require('WAWebWidFactory')
                     .createWid(chatId);
                 const chat = await window.WWebJS.getChat(chatId, {
                     getAsModel: false,
                 });
-                let descId = chat.groupMetadata.descId;
+                let descId = chat.groupMetadata?.descId;
                 let newId = await window.require('WAWebMsgKey').newId();
                 try {
                     await window
                         .require('WAWebGroupModifyInfoJob')
-                        .setGroupDescription(
-                            chatWid,
-                            description,
-                            newId,
-                            descId,
-                        );
+                        .setGroupDescription({
+                            desc: description,
+                            groupWid: chatWid,
+                            newDescId: newId,
+                            prevDescId: descId,
+                        });
                     return true;
                 } catch (err) {
                     if (err.name === 'ServerStatusCodeError') return false;


### PR DESCRIPTION
## Description
Change setDescription to accept an object instead of positional arguments, making each argument explicit to comply with the new WhatsApp Web version. Fix the error bellow when call setDescription. Await chatWid before passing it to setDescription and use optional chaining when accessing descId to safely handle missing values.

```sh
Error [TypeError]: Cannot read properties of undefined (reading 'toJid')g (https://static.whatsapp.net/rsrc.php/v4/y7/r/Pc4nmzfROLz.js:186:118)
Object.b [as widToGroupJid] (https://static.whatsapp.net/rsrc.php/v4/y7/r/Pc4nmzfROLz.js:186:1715) at evaluate (evaluate at GroupChat.setDescription (/home/develop/botwhats/node_modules/whatsapp-web.js/src/structures/GroupChat.js:410:51), <anonymous>:13:25)
```
I tried to make minimal changes to the current implementation to preserve the existing code pattern.


### Previous setDescription(in main)
<img width="546" height="587" alt="image" src="https://github.com/user-attachments/assets/3488e748-1680-4f7e-8616-09d5d8530b5b" />

### Sugested setDescription
<img width="1512" height="1584" alt="setDescription" src="https://github.com/user-attachments/assets/f12c64a7-46e8-4337-8f78-0ddb5a639f74" />


<!-- What does this PR change and why? -->

## Related Issue(s)
- I couldn't identify an issue with this, but I encountered this error in production. After modifying my base code, the setDescription method ran again without errors.
<!--
If this pull request relates to one or more GitHub issues, link them using GitHub's closing keywords to automatically close the issues upon merging.

Examples:
  closes #123
  fixes #456
  resolves #789

For more details, see:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Testing Summary

### Test Details

<!-- Describe in detail how you tested your changes. -->

### Environment

<!-- Provide detailed information about the environment used to test this pull request. Simply fill out the blanks with your setup. -->

<!-- Operating system of the machine used for testing -->
<!-- Example: (macOS 15 / Windows 11 / Ubuntu 24 / ...) -->

- Machine OS:
  - Ubuntu 24.04.4 LTS
<!-- Operating system of the mobile device used to verify functionality -->
<!-- Example: (Android 12 / iOS 16 / ...) -->

- Phone OS:
  - Xiaomi Redmi Note 14S
  - HyperOS 3.0.304
  - Android 16BP2A.250606.031.A3
  
<!-- Version of whatsapp-web.js used during testing -->
<!-- Check your `package.json` file -->
<!-- Example: (1.31.0) -->

- Library Version:
  - 1.34.7

<!-- WhatsApp Web version used for testing -->
<!-- Run `await client.getWWebVersion()` to retrieve it -->
<!-- Example: (2.3000.1017054665) -->

- WhatsApp Web Version:
  - Version 2.3000.1045456189
<!-- Browser and version used for testing -->
<!-- Example: (Chromium 120 / Google Chrome 118 / ...) -->

- Browser Type and Version:
  - Google Chrome 151.0.7922.137
<!-- Node.js version used during testing -->
<!-- Run `node -v` to check -->
<!-- Example: (18.16.0) -->

- Node Version:
  - Nodejs v25.2.1
## Type of Change

<!-- Select all that apply: -->

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [X] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

<!-- Please confirm that all relevant items below have been completed. -->

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
