### PR TITLE
fix: restore session persistence and media download compatibility

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -12,6 +12,7 @@ const {
     WAState,
     MessageTypes,
 } = require('./util/Constants');
+const { ExposeAuthStore } = require('./util/Injected/AuthStore/AuthStore');
 const { LoadUtils } = require('./util/Injected/Utils');
 const ChatFactory = require('./factories/ChatFactory');
 const ContactFactory = require('./factories/ContactFactory');
@@ -135,6 +136,8 @@ class Client extends EventEmitter {
             );
             const pairWithPhoneNumber = this.options.pairWithPhoneNumber;
             const version = await this.getWWebVersion();
+
+            await this.pupPage.evaluate(ExposeAuthStore);
 
             const needAuthHandle = await this.pupPage.waitForFunction(
                 () => {

--- a/src/structures/Contact.js
+++ b/src/structures/Contact.js
@@ -158,20 +158,15 @@ class Contact extends Base {
             const contact = await window
                 .require('WAWebCollections')
                 .Contact.find(contactId);
-            const lid = contact.id.isLid()
-                ? contact.id
-                : window
-                      .require('WAWebApiContact')
-                      .getAlternateUserWid(contact.id);
-            const ContactToBlock = {
-                id: lid,
-                isContactBlocked: false,
-                phoneNumber: null,
-            };
-            await window.require('WAWebBlockContactAction').blockContact({
-                contact: ContactToBlock,
-                blockEntryPoint: 'ChatListBlock',
-            });
+            const resolved = window
+                .require('WAWebBlockContactUtils')
+                .getContactToBlockOnlyUseIfNoAssociatedChat(
+                    contact,
+                    'ChatListBlock',
+                );
+            await window
+                .require('WAWebBlockContactAction')
+                .blockContact({ contact: resolved });
         }, this.id._serialized);
 
         this.isBlocked = true;
@@ -186,21 +181,18 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            let contact = await window
+            const contact = await window
                 .require('WAWebCollections')
                 .Contact.find(contactId);
-            if (!contact.id.isLid()) {
-                const lid = window
-                    .require('WAWebApiContact')
-                    .getAlternateUserWid(contact.id);
-
-                contact = await window
-                    .require('WAWebCollections')
-                    .Contact.find(lid._serialized);
-            }
+            const resolved = window
+                .require('WAWebBlockContactUtils')
+                .getContactToBlockOnlyUseIfNoAssociatedChat(
+                    contact,
+                    'ChatListBlock',
+                );
             await window
                 .require('WAWebBlockContactAction')
-                .unblockContact(contact, 'ChatListBlock');
+                .unblockContact(resolved);
         }, this.id._serialized);
 
         this.isBlocked = false;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -36,6 +36,9 @@ class Message extends Base {
          * @type {object}
          */
         this.id = data.id;
+        if (this.id && !this.id._serialized && this.id.$1) {
+            this.id._serialized = this.id.$1;
+        }
 
         /**
          * ACK status for the message

--- a/src/util/Injected/AuthStore/AuthStore.js
+++ b/src/util/Injected/AuthStore/AuthStore.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.ExposeAuthStore = () => {
+    window.AuthStore = {};
+    window.AuthStore.AppState = window.require('WAWebSocketModel').Socket;
+    window.AuthStore.Cmd = window.require('WAWebCmd').Cmd;
+    window.AuthStore.Conn = window.require('WAWebConnModel').Conn;
+    window.AuthStore.OfflineMessageHandler = window.require(
+        'WAWebOfflineHandler',
+    ).OfflineMessageHandler;
+    window.AuthStore.PairingCodeLinkUtils = window.require(
+        'WAWebAltDeviceLinkingApi',
+    );
+    window.AuthStore.Base64Tools = window.require('WABase64');
+    window.AuthStore.RegistrationUtils = {
+        ...window.require('WAWebCompanionRegClientUtils'),
+        ...window.require('WAWebAdvSignatureApi'),
+        ...window.require('WAWebUserPrefsInfoStore'),
+        ...window.require('WAWebSignalStoreApi'),
+    };
+};


### PR DESCRIPTION
## Description

Fixes session persistence and media downloads breaking on recent WhatsApp Web bundles.

- Introduce `AuthStore.js` for clean WhatsApp internal module injection, ensuring the auth state is properly exposed and the session is correctly saved/restored (`LocalAuth`)
- Add fallback for missing `message.id._serialized` via `id.$1`, restoring `message.downloadMedia()` which relies on `id._serialized` to fetch attachments
- Refactor contact block/unblock to use `WAWebBlockContactUtils` for compatibility with the current bundle

### Root Cause
Confirmed via debug logging at `Message` construction time that on the current WWeb bundle, some messages arrive with `id._serialized` genuinely absent with only the minified `id.$1` field carries the equivalent serialized string:

```json
{"fromMe":true,"remote":"REDACTED@lid","id":"ACA48A186FBD2A8024FA43EB5EC78480","self":"out","$1":"true_REDACTED@lid_ACA48A186FBD2A8024FA43EB5EC78480_out"}
```

Since `message.downloadMedia()` (and other methods) rely on `id._serialized` being present, this caused `downloadMedia()` to throw for affected messages.

Note: in earlier testing I also observed at least one case where `_serialized` was present yet media download still failed on the original code with an opaque internal error (`r: r`, thrown inside WWeb's own bundle via `page.evaluate`). I haven't fully isolated that case, it may be a separate, intermittent issue rather than something this fallback addresses.

## Related Issue(s)

## Testing Summary

### Test Details

Verified locally end-to-end with `LocalAuth`:

- Started client, scanned QR code from phone
- `authenticated` and `ready` events fired correctly, session persisted in `.wwebjs_auth/` and was correctly restored on restart
- Received incoming messages via `message_create`, the media (images, videos etc.) downloaded and saved successfully
- Confirmed via debug logging that the `id.$1` fallback triggers specifically when `id._serialized` is absent at message construction
- No regressions observed in message ID handling

### Environment

- Machine OS: Kali Linux (Debian-based)
- Phone OS: Android 16 (Samsung Galaxy M33)
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1045521823
- Browser Type and Version: Chromium 146.0.7680.31
- Node Version: v24.18.0

## Type of Change

- [x] **Bug fix** _(non-breaking change that fixes an issue)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.