### PR TITLE
fix: close leaked browser when initialize() fails

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -482,59 +482,80 @@ class Client extends EventEmitter {
         await this.authStrategy.beforeBrowserInitialized();
 
         const puppeteerOpts = this.options.puppeteer;
-        if (
+        const connectingToExistingBrowser = !!(
             puppeteerOpts &&
             (puppeteerOpts.browserWSEndpoint || puppeteerOpts.browserURL)
-        ) {
-            browser = await puppeteer.connect(puppeteerOpts);
-            page = await browser.newPage();
-        } else {
-            const browserArgs = [...(puppeteerOpts.args || [])];
-            if (
-                this.options.userAgent !== false &&
-                !browserArgs.find((arg) => arg.includes('--user-agent'))
-            ) {
-                browserArgs.push(`--user-agent=${this.options.userAgent}`);
+        );
+
+        try {
+            if (connectingToExistingBrowser) {
+                browser = await puppeteer.connect(puppeteerOpts);
+                page = await browser.newPage();
+            } else {
+                const browserArgs = [...(puppeteerOpts.args || [])];
+                if (
+                    this.options.userAgent !== false &&
+                    !browserArgs.find((arg) => arg.includes('--user-agent'))
+                ) {
+                    browserArgs.push(`--user-agent=${this.options.userAgent}`);
+                }
+                // navigator.webdriver fix
+                browserArgs.push(
+                    '--disable-blink-features=AutomationControlled',
+                );
+
+                browser = await puppeteer.launch({
+                    ...puppeteerOpts,
+                    args: browserArgs,
+                });
+                page = (await browser.pages())[0];
             }
-            // navigator.webdriver fix
-            browserArgs.push('--disable-blink-features=AutomationControlled');
 
-            browser = await puppeteer.launch({
-                ...puppeteerOpts,
-                args: browserArgs,
+            if (this.options.proxyAuthentication !== undefined) {
+                await page.authenticate(this.options.proxyAuthentication);
+            }
+            if (this.options.userAgent !== false) {
+                await page.setUserAgent(this.options.userAgent);
+            }
+            if (this.options.bypassCSP) await page.setBypassCSP(true);
+
+            this.pupBrowser = browser;
+            this.pupPage = page;
+
+            await this.authStrategy.afterBrowserInitialized();
+            await this.initWebVersionCache();
+
+            if (this.options.evalOnNewDoc !== undefined) {
+                await page.evaluateOnNewDocument(this.options.evalOnNewDoc);
+            }
+
+            await page.goto(WhatsWebURL, {
+                waitUntil: 'load',
+                timeout: 0,
+                referer: 'https://whatsapp.com/',
             });
-            page = (await browser.pages())[0];
+
+            // Register framenavigated BEFORE inject so that if navigation
+            // interrupts inject, the handler triggers a fresh inject.
+            this._registerFramenavigatedHandler();
+
+            await this.inject();
+        } catch (err) {
+            // A browser we launched ourselves (as opposed to one we merely
+            // connected to via browserWSEndpoint/browserURL, which the
+            // caller owns and is responsible for closing) must be closed
+            // here on failure. Without this, a rejected initialize() still
+            // leaves `this.pupBrowser` pointing at a live Chromium process
+            // tree with nothing left to close it - callers that retry
+            // initialize() after a failure (a common and reasonable pattern,
+            // since a transient CDP/protocol error is often recoverable)
+            // leak one full Chromium instance per failed attempt, which
+            // compounds quickly under load. See #3976.
+            if (!connectingToExistingBrowser && browser?.isConnected?.()) {
+                await browser.close().catch(() => {});
+            }
+            throw err;
         }
-
-        if (this.options.proxyAuthentication !== undefined) {
-            await page.authenticate(this.options.proxyAuthentication);
-        }
-        if (this.options.userAgent !== false) {
-            await page.setUserAgent(this.options.userAgent);
-        }
-        if (this.options.bypassCSP) await page.setBypassCSP(true);
-
-        this.pupBrowser = browser;
-        this.pupPage = page;
-
-        await this.authStrategy.afterBrowserInitialized();
-        await this.initWebVersionCache();
-
-        if (this.options.evalOnNewDoc !== undefined) {
-            await page.evaluateOnNewDocument(this.options.evalOnNewDoc);
-        }
-
-        await page.goto(WhatsWebURL, {
-            waitUntil: 'load',
-            timeout: 0,
-            referer: 'https://whatsapp.com/',
-        });
-
-        // Register framenavigated BEFORE inject so that if navigation
-        // interrupts inject, the handler triggers a fresh inject.
-        this._registerFramenavigatedHandler();
-
-        await this.inject();
     }
 
     _registerFramenavigatedHandler() {


### PR DESCRIPTION
## Problem

Closes #3976.

If `initialize()` rejects *after* `puppeteer.launch()`/`puppeteer.connect()` succeeds (for example, an error thrown inside `inject()` such as `"auth timeout"` or `"Execution context was destroyed, most likely because of a navigation."`), the browser that was just launched is never closed. `this.pupBrowser` still points at a live Chromium process tree, but the rejected promise leaves nothing holding a reference that would call `browser.close()`.

Retrying `initialize()` after a failure is a reasonable, common pattern - these errors are frequently transient (slow/loaded machine, a WhatsApp Web reload mid-injection, etc.). But without this fix, every retry leaks one full Chromium process tree on top of the previous one. On constrained hardware (small VPS/containers, which is a common deployment target for this library per the README), this compounds quickly: each leaked instance adds CPU/memory pressure, which makes the next attempt more likely to fail too, in a downward spiral that can take the whole host down before an explicit retry-limit kicks in.

Observed in production on a 1-vCPU/1GB VM: after ~5 retries the host had 5+ orphaned Chromium `--type=renderer` processes and a load average >9, all Puppeteer launches then timing out waiting for the WS endpoint (unrelated errors that were really just resource starvation caused by the leak).

## Fix

Wrap the browser setup + `inject()` call in `initialize()` in a try/catch. On failure, close the browser we launched - unless we merely *connected* to an existing one via `browserWSEndpoint`/`browserURL`, since in that case the caller owns its lifecycle and closing it out from under them would be wrong.

## Testing

- `npm run lint` / `npm run format:check` pass on the changed file.
- Manually verified against the failure modes above on the affected host: after the fix, a failed `initialize()` no longer leaves an orphaned Chromium process behind, and repeated retries no longer accumulate load.
- I did not see existing unit tests covering `initialize()`'s failure path (most tests in this repo appear to need a live session) - happy to add coverage if there's a preferred way to mock the puppeteer layer here.