### PR TITLE
fix(client): sendMessage returns undefined on newer WA Web builds

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -580,9 +580,19 @@ exports.LoadUtils = () => {
 
         if (options.waitUntilMsgSent) await sendMsgResultPromise;
 
-        return window
-            .require('WAWebCollections')
-            .Msg.get(newMsgKey._serialized);
+        // Newer WA Web builds (2.3000.1043xxx+) no longer expose `_serialized` on a
+        // MsgKey; the same value is only reachable through `$1` or `toString()`.
+        // Without a fallback the just-created message is looked up by `undefined`,
+        // so this resolves to `undefined` and `Client.sendMessage` returns
+        // `undefined` even though the message was sent.
+        const sentMsgId =
+            newMsgKey._serialized ??
+            newMsgKey.$1 ??
+            (typeof newMsgKey.toString === 'function'
+                ? newMsgKey.toString()
+                : undefined);
+
+        return window.require('WAWebCollections').Msg.get(sentMsgId);
     };
 
     window.WWebJS.editMessage = async (msg, content, options = {}) => {


### PR DESCRIPTION
## Description

On WA Web `2.3000.1043xxx+` a `MsgKey` no longer exposes `_serialized`. The value is
still there — reachable through the minified `$1` property and through `toString()` —
but the named property is gone.

`WWebJS.sendMessage` ends by looking the freshly created message up by that property:

```js
return window.require('WAWebCollections').Msg.get(newMsgKey._serialized);
```

On these builds this is `Msg.get(undefined)`, which returns nothing, so
`Client.sendMessage` resolves to `undefined` — **even though the message was actually
delivered**. Callers that check the return value report a successful send as a failure,
and no message id is available for tracking acks.

This PR falls back to `$1` and then to `toString()`, keeping `_serialized` first so
older builds take exactly the same path as before.

### Relationship to #201840

#201840 covers the **read** path (`getMessageModel`, `getChatModel`, `Message._patch`,
`downloadMedia`) and does not touch this line. The two changes are complementary and do
not overlap:

- With #201840 alone, `Client.sendMessage` still resolves to `undefined`, because the
  lookup fails before `getMessageModel` is ever reached.
- With this PR alone, `sendMessage` returns the `Message` again, but its node-side
  `id._serialized` is still `undefined` — that part is what `normalizeSerialized` in
  #201840 fixes.

I kept this patch minimal and self-contained on `main` rather than building on #201840,
so it can land independently. Happy to rebase it onto that PR's helpers
(`widSerialized`) instead if the maintainers prefer a single entry point.

## Related Issue(s)

Related to #201836 (`sendMessage` returning an empty message id) and #201862.

I have deliberately not used a closing keyword: those reports do not state the WA Web
build precisely enough for me to confirm they are the same root cause, and I would
rather not auto-close someone else's issue on an assumption.

## Testing Summary

### Test Details

Verified against a live WhatsApp Web session, sending to a self-chat, with the library
copied to a scratch directory so the same session could be reused between runs. No
other patches were applied, so the result isolates this change.

**Before (unpatched `main`):**

```
sendMessage returned UNDEFINED
```

**After (this patch, nothing else changed):**

```
sendMessage returned Message (id._serialized=undefined)
```

The message was delivered in both runs — confirming the send itself was never broken,
only the lookup of its own result. The remaining `id._serialized=undefined` on the node
side is the part #201840 addresses.

Supporting observations from the same session, for whoever picks this up:

- A freshly built `MsgKey` has own properties `fromMe`, `remote`, `id`, `$1` — no
  `_serialized`; its prototype only carries `constructor`, `toString`, `clone`, `equals`.
- `$1` and `toString()` return the same string
  (`true_<remote>_<id>` / `true_<remote>_<id>_<participant>` for groups), which is why
  either works as a fallback.

`npm run check` passes (ESLint clean; Prettier reports only a pre-existing warning on
`index.d.ts`, which is present on unmodified `main` and is untouched here).

`npm test` could not be run: the suite requires `WWEBJS_TEST_REMOTE_ID` and a dedicated
paired account, and it fails to load without them on unmodified `main` too. I did not
point it at a production session. The manual verification above is what I have.

### Environment

- Machine OS: Ubuntu 24.04.4 LTS
- Phone OS: not recorded
- Library Version: 1.34.7 (change authored against `main` @ 942d236, where the affected
  line is byte-identical)
- WhatsApp Web Version: 2.3000.1046520132
- Browser Type and Version: Chrome/146.0.7680.31 (puppeteer bundled Chromium)
- Node Version: v20.20.2

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`). — see Test Details: the suite needs a
      dedicated paired test account; `npm run check` passes.
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary. — no typing change; the
      public signature is unchanged, this only stops it returning `undefined`.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. —
      not applicable, internal lookup only.
