### PR TITLE
fix(message): recover uncached media downloads

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1152,6 +1152,40 @@ exports.LoadUtils = () => {
             blob = msg.mediaObject.mediaBlob.forceToBlob();
         }
 
+        if (!blob && msg.directPath) {
+            const mockQpl = {
+                addAnnotations() {
+                    return this;
+                },
+                addPoint() {
+                    return this;
+                },
+            };
+
+            try {
+                const decryptedMedia = await window
+                    .require('WAWebDownloadManager')
+                    .downloadManager.downloadAndMaybeDecrypt({
+                        directPath: msg.directPath,
+                        encFilehash: msg.encFilehash,
+                        filehash: msg.filehash,
+                        mediaKey: msg.mediaKey,
+                        mediaKeyTimestamp: msg.mediaKeyTimestamp,
+                        type: msg.type,
+                        mimetype: msg.mimetype,
+                        signal: new AbortController().signal,
+                        downloadQpl: mockQpl,
+                    });
+
+                blob = new Blob([decryptedMedia], {
+                    type: msg.mimetype,
+                });
+            } catch (err) {
+                if (err?.status === 404) return null;
+                throw err;
+            }
+        }
+
         if (!blob) return null;
 
         return {

--- a/tests/util/injected.js
+++ b/tests/util/injected.js
@@ -1,0 +1,108 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { LoadUtils } = require('../../src/util/Injected/Utils');
+
+describe('Injected Utils', function () {
+    let originalWindow;
+
+    beforeEach(function () {
+        originalWindow = global.window;
+        global.window = {
+            require() {
+                return undefined;
+            },
+        };
+        LoadUtils();
+    });
+
+    afterEach(function () {
+        global.window = originalWindow;
+        sinon.restore();
+    });
+
+    describe('resolveMediaBlob', function () {
+        function createMessage(overrides = {}) {
+            return {
+                mediaData: { mediaStage: 'INIT' },
+                mediaObject: { filehash: 'file-hash' },
+                directPath: '/media/path',
+                encFilehash: 'encrypted-file-hash',
+                filehash: 'file-hash',
+                mediaKey: 'media-key',
+                mediaKeyTimestamp: 123,
+                type: 'image',
+                mimetype: 'image/jpeg',
+                filename: 'photo.jpg',
+                size: 3,
+                downloadMedia: sinon.stub().resolves(),
+                ...overrides,
+            };
+        }
+
+        it('uses the media blob cache without invoking the fallback', async function () {
+            const cachedBlob = new Blob([new Uint8Array([1, 2, 3])], {
+                type: 'image/jpeg',
+            });
+            const message = createMessage();
+            const downloadAndMaybeDecrypt = sinon.stub();
+
+            window.require = (module) => {
+                if (module === 'WAWebCollections') {
+                    return { Msg: { get: () => message } };
+                }
+                if (module === 'WAWebMediaInMemoryBlobCache') {
+                    return {
+                        InMemoryMediaBlobCache: { get: () => cachedBlob },
+                    };
+                }
+                if (module === 'WAWebDownloadManager') {
+                    return { downloadManager: { downloadAndMaybeDecrypt } };
+                }
+            };
+
+            const result = await window.WWebJS.resolveMediaBlob('message-id');
+
+            expect(result.blob).to.equal(cachedBlob);
+            expect(downloadAndMaybeDecrypt.called).to.equal(false);
+        });
+
+        it('downloads uncached media with its declared MIME type', async function () {
+            const decryptedMedia = new Uint8Array([1, 2, 3]).buffer;
+            const message = createMessage();
+            const downloadAndMaybeDecrypt = sinon
+                .stub()
+                .resolves(decryptedMedia);
+
+            window.require = (module) => {
+                if (module === 'WAWebCollections') {
+                    return { Msg: { get: () => message } };
+                }
+                if (module === 'WAWebMediaInMemoryBlobCache') {
+                    return { InMemoryMediaBlobCache: { get: () => null } };
+                }
+                if (module === 'WAWebDownloadManager') {
+                    return { downloadManager: { downloadAndMaybeDecrypt } };
+                }
+            };
+
+            const result = await window.WWebJS.resolveMediaBlob('message-id');
+
+            expect(downloadAndMaybeDecrypt.calledOnce).to.equal(true);
+            expect(downloadAndMaybeDecrypt.firstCall.args[0]).to.include({
+                directPath: message.directPath,
+                encFilehash: message.encFilehash,
+                filehash: message.filehash,
+                mediaKey: message.mediaKey,
+                mediaKeyTimestamp: message.mediaKeyTimestamp,
+                type: message.type,
+                mimetype: message.mimetype,
+            });
+            expect(result.mimetype).to.equal('image/jpeg');
+            expect(result.blob.type).to.equal('image/jpeg');
+            expect(
+                new Uint8Array(await result.blob.arrayBuffer()),
+            ).to.deep.equal(new Uint8Array(decryptedMedia));
+        });
+    });
+});


### PR DESCRIPTION
## Description

`resolveMediaBlob()` currently delegates to the WhatsApp Web `msg.downloadMedia()` method and then reads the resulting blob from the in-memory caches. For some uncached media messages, that call completes while the media remains at the `INIT` stage and no blob is stored.

This change preserves the existing download and cache path. When it produces no blob and the message has a `directPath`, it falls back to `DownloadManager.downloadAndMaybeDecrypt()` and includes `msg.mimetype` in the download payload. The decrypted data is returned as a `Blob` with the same MIME type. HTTP 404 continues to resolve as no media, while other errors are propagated.

The tests cover both paths:

- cached media is returned without invoking the fallback;
- uncached media is downloaded with its declared MIME type and returned as a correctly typed blob.

## Related Issue(s)

Fixes #201908

## Testing Summary

### Test Details

- Targeted unit tests pass: `npx mocha tests/util/injected.js` (2 passing).
- `npm run lint` passes.
- Prettier validation passes for both changed files.
- Live diagnostic verification recovered all 11 affected JPEG messages. Each result had the expected MIME type and size, matched the message SHA-256 file hash, had valid JPEG boundaries, and decoded successfully in Chromium.
- The repository-wide `npm run check` is currently blocked by a pre-existing Prettier failure in the unchanged `index.d.ts`; the files in this PR pass the same formatting check.
- The full integration `npm test` suite was not run because it requires a dedicated authenticated WhatsApp test session and remote test number and sends live messages. This is why the PR is initially marked as draft.

### Environment

- Machine OS: Debian GNU/Linux 12 (container)
- Phone OS: Not recorded; the reproduced failure is in the WhatsApp Web media-download path
- Library Version: current `main` at `942d236`; originally reproduced with `1.34.7`
- WhatsApp Web Version: `2.3000.1046964124`
- Browser Type and Version: Chromium `150.0.7871.124`
- Node Version: `22.23.1`

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
